### PR TITLE
fix: make down.nvim functional as a Neovim plugin with LSP/MCP auto-download and knowledge graph

### DIFF
--- a/lua/down.lua
+++ b/lua/down.lua
@@ -12,79 +12,114 @@
 ---@class down.Down
 local Down = {
   --- The configuration for the plugin
-  config = require("down.config"),
+  config = require ("down.config"),
   --- The module logic for the plugin
-  mod = require("down.mod"),
+  mod = require ("down.mod"),
   --- The event logic for the plugin
-  event = require("down.event"),
+  event = require ("down.event"),
   --- The utility logic for the plugin
-  util = require("down.util"),
+  util = require ("down.util"),
   --- The log logic for the plugin
-  log = require("down.log"),
+  log = require ("down.log"),
+}
+
+--- Default modules that are always loaded
+Down.default_mods = {
+  "cmd",
+  "workspace",
+  "data",
+  "note",
+  "find",
+  "lsp",
+  "mcp",
+  "data.knowledge",
 }
 
 --- Load the user configuration, and load into config
 --- defined modules specifieed and workspaces
 --- @param user_config down.config.User user config to load
 --- @param ... string The arguments to pass into an optional user hook
-Down.setup = function(user_config, ...)
-  Down.log.trace("Setting up down")
-  Down.config:setup(user_config, ...)
-  Down:start()
+Down.setup = function (user_config, ...)
+  Down.log.trace ("Setting up down")
+  Down.config:setup (user_config, ...)
+  Down:start ()
 end
 
 --- *Start* the ^down.nvim^ plugin
 --- Load the workspace and user modules
-function Down:start()
-  self.log.trace("Starting down")
-  self.mod.load_mod(
-    "workspace",
-    self.config.user.workspace or self.config.user.workspaces
-  )
-  for name, usermod in pairs(self.config.user) do
-    if self.mod.check_id(name) then
-      self.mod.load_mod(name, usermod)
+function Down:start ()
+  self.log.trace ("Starting down")
+
+  -- Load workspace first with user config
+  local ws_config = self.config.user.workspace
+    or self.config.user.workspaces
+    or {}
+  self.mod.load_mod ("workspace", ws_config)
+
+  -- Load default modules
+  for _, name in ipairs (Down.default_mods) do
+    if not self.mod.is_loaded (name) then
+      local mod_config = self.config.user[name]
+      if type (mod_config) == "table" then
+        self.mod.load_mod (name, mod_config)
+      elseif mod_config ~= false then
+        self.mod.load_mod (name)
+      end
     end
   end
-  self:after()
+
+  -- Load user-specified modules
+  for name, usermod in pairs (self.config.user) do
+    if self.mod.check_id (name) and not self.mod.is_loaded (name) then
+      if type (usermod) == "table" then
+        self.mod.load_mod (name, usermod)
+      elseif usermod ~= false then
+        self.mod.load_mod (name)
+      end
+    end
+  end
+
+  self:after ()
 end
 
 --- After the plugin has started
-function Down:after()
-  self.config:after()
-  for _, l in pairs(self.mod.mods) do
-    self.event.load_callback(l)
-    l.after()
+function Down:after ()
+  self.config:after ()
+  for _, l in pairs (self.mod.mods) do
+    self.event.load_callback (l)
+    if l.after then
+      l.after ()
+    end
   end
-  self:broadcast("started")
+  self:broadcast ("started")
 end
 
 --- Broadcast the message `e` or the 'started' event to all modules
 ---@param e string
 ---@param ... any
-function Down:broadcast(e, ...)
+function Down:broadcast (e, ...)
   ---@type down.Event
-  local ev = self.event.define("down", e or "started")
-  self.event.broadcast_to(ev, Down.mod.mods)
-end
-
---- Test all modules loaded
-function Down:test()
-  Down.config:test()
-  for m, d in pairs(Down.mod.mods) do
-    Down.log.trace("Testing mod: " .. m)
-    Down.log.trace("Result: " .. d.test())
+  local ev = self.event.define ("down", e or "started")
+  for _, m in pairs (Down.mod.mods) do
+    if m.handle and m.handle["down"] and m.handle["down"][e] then
+      m.handle["down"][e] (ev)
+    end
   end
 end
 
-return setmetatable(Down, {
-  __call = function(down, user, ...)
-    Down.setup(user, ...)
+--- Test all modules loaded
+function Down:test ()
+  Down.config:test ()
+  for m, d in pairs (Down.mod.mods) do
+    Down.log.trace ("Testing mod: " .. m)
+    if d.test then
+      Down.log.trace ("Result: " .. tostring (d.test ()))
+    end
+  end
+end
+
+return setmetatable (Down, {
+  __call = function (_, user, ...)
+    Down.setup (user, ...)
   end,
-  -- __index = function(Down, key)
-  --   return down.mod.mods[key]
-  -- end,
-  -- __newindex = function(Down, key, val)
-  --   down.mod.mods[key] = val
-  -- end,
 })

--- a/lua/down/config.lua
+++ b/lua/down/config.lua
@@ -1,6 +1,6 @@
-local log = require("down.log")
-local mod = require("down.mod")
-local modconf = require("down.mod.util")
+local log = require ("down.log")
+local mod = require ("down.mod")
+local modconf = require ("down.mod.util")
 
 --- The down.nvim configuration
 --- @class down.Config
@@ -59,21 +59,21 @@ Config.dependencies = {
 --- Default command for down.nvim, specified in user's config
 Config.command = { "Down" }
 
-function Config:check_hook(...)
-  if self.user.hook and type(self.user.hook) == "function" then
-    return self.user.hook(...)
+function Config:check_hook (...)
+  if self.user.hook and type (self.user.hook) == "function" then
+    return self.user.hook (...)
   end
 end
 
 ---@param k? down.config.Toggle
 ---@param v? boolean
-function Config:check_toggle(k, v)
+function Config:check_toggle (k, v)
   if
     k
-    and type(k) == "string"
+    and type (k) == "string"
     and v
-    and type(v) == "boolean"
-    and vim.tbl_contains(self.toggles, k)
+    and type (v) == "boolean"
+    and vim.tbl_contains (self.toggles, k)
   then
     self[k] = v
   end
@@ -83,65 +83,65 @@ end
 ---@param user down.mod.Config user config
 ---@param ... any
 ---@return down.Config
-function Config:load(user, ...)
-  if
-    (self.started and self.started == false)
-    or (not type(user) == "table")
-    or (type(user) == "nil")
-  then
+function Config:load (user, ...)
+  if self.started then
     return self
-  elseif user.defaults and user.defaults == false then
+  end
+  if type (user) ~= "table" or user == nil then
+    user = {}
+  end
+  if user.defaults == false then
     self.user = user
   else
-    self.user = vim.tbl_extend("force", user, modconf.defaults)
+    self.user = vim.tbl_deep_extend ("force", modconf.defaults, user)
   end
-  vim.iter(pairs(self.user)):map(function(k, v)
-    self:check_toggle(k, v)
+  vim.iter (pairs (self.user)):map (function (k, v)
+    self:check_toggle (k, v)
   end)
-  self:check_hook(...)
+  self:check_hook (...)
   self.started = true
 end
 
-function Config:after()
-  return self:check_tests(require("down.mod").mods or self.user) ---@type boolean?
+function Config:after ()
+  return self:check_tests (require ("down.mod").mods or self.user) ---@type boolean?
 end
 
 --- @param ... string
 --- @return string
-function Config.vimdir(...)
-  local d = vim.fs.joinpath(vim.fn.stdpath("data"), "down/")
-  vim.fn.mkdir(d, "p")
-  local dir = vim.fs.joinpath("data", ...)
+function Config.vimdir (...)
+  local d = vim.fs.joinpath (vim.fn.stdpath ("data"), "down/")
+  vim.fn.mkdir (d, "p")
+  local dir = vim.fs.joinpath ("data", ...)
   return dir
 end
 
 --- @param ... string
 --- @return string
-function Config.homedir(...)
-  local d = vim.fs.joinpath(os.getenv("HOME") or "~/", ".down/", ...)
-  vim.fn.mkdir(d, "p")
+function Config.homedir (...)
+  local d = vim.fs.joinpath (os.getenv ("HOME") or "~/", ".down/", ...)
+  vim.fn.mkdir (d, "p")
   return d
 end
 
 --- @param fp? string
 --- @return string
-function Config:file(fp)
-  local f = vim.fs.joinpath(fp or self.vimdir("down.json"))
+function Config:file (fp)
+  local f = vim.fs.joinpath (fp or self.vimdir ("down.json"))
 end
 
 --- @param f string | nil
 --- @return down.config.User
-function Config.fromfile(f)
-  local file = vim.fn.readfile(Config.file(f))
-  local conf = vim.json.decode(file) ---@type down.config.User
+function Config.fromfile (f)
+  local file = vim.fn.readfile (Config.file (f))
+  local conf = vim.json.decode (file) ---@type down.config.User
   return conf
 end
 
 --- @param f string | nil
-function Config:save(f)
-  local json = vim.json.encode(self.user)
-  json = vim.fn.str2list(json)
-  return vim.fn.writefile(json, self:file(f), "S")
+function Config:save (f)
+  local json = vim.json.encode (self.user)
+  json = vim.fn.str2list (json)
+  return vim.fn.writefile (json, self:file (f), "S")
 end
 
 --- Setup the down config
@@ -149,63 +149,66 @@ end
 --- @param user down.mod.Config user config to load
 --- @param ... any The arguments to pass into an optional user hook
 --- @return down.Config
-function Config:setup(user, ...)
-  log.new(log.config, false)
-  log.info("Config.setup: Log started")
-  return self:load(user, ...)
+function Config:setup (user, ...)
+  log.new (log.config, false)
+  log.info ("Config.setup: Log started")
+  return self:load (user, ...)
 end
 
 ---@param mods? { [down.Mod.Id]?: down.Mod.Mod }
 ---@return boolean?
-function Config:check_tests(mods)
+function Config:check_tests (mods)
   if not self.test then
     return
   elseif self.test == false then
     return false
   elseif self.test and self.test == true then
-    return self:tests(mods or vim.iter(self.user or mods):filter(function(m)
-      return self.check_mod_test(m)
+    return self:tests (mods or vim.iter (self.user or mods):filter (function (m)
+      return self.check_mod_test (m)
     end))
   end
 end
 
 ---@param mod down.Mod.Mod`
 ---@return boolean
-function Config.check_mod_test(mod)
+function Config.check_mod_test (mod)
   return mod ~= nil
     and mod.id ~= nil
-    and modconf.check_id(mod.id)
-    and type(mod) == "table"
+    and modconf.check_id (mod.id)
+    and type (mod) == "table"
     and mod.tests ~= nil
-    and type(mod.tests) == "table"
-    and not vim.tbl_isempty(mod.tests)
+    and type (mod.tests) == "table"
+    and not vim.tbl_isempty (mod.tests)
 end
 
 ---@param mods? down.Mod.Mod[]
 ---@return boolean
-function Config:tests(mods)
-  vim.print("Testing config", vim.inspect(self))
-  return vim.iter(mods or self.user):filter(self.check_mod_test):all(function(m)
-    return self.test(m)
-  end)
+function Config:tests (mods)
+  vim.print ("Testing config", vim.inspect (self))
+  return vim
+    .iter (mods or self.user)
+    :filter (self.check_mod_test)
+    :all (function (m)
+      return self.test (m)
+    end)
 end
 
 ---@param mod down.Mod.Mod
 ---@return boolean
-function Config.test(mod)
-  vim.print("Testing " .. tostring(vim.inspect(mod.id)))
+function Config.test (mod)
+  vim.print ("Testing " .. tostring (vim.inspect (mod.id)))
   return vim
-    .iter(pairs(mod.tests))
-    :filter(function(tn, t)
-      return tn and type(t) == "function"
+    .iter (pairs (mod.tests))
+    :filter (function (tn, t)
+      return tn and type (t) == "function"
     end)
-    :all(function(tn, tt)
-      if not type(tt) == "function" then
+    :all (function (tn, tt)
+      if not type (tt) == "function" then
         return false
       end
-      local res = tt(mod) or false ---@type boolean
-      vim.print(
-        "Testing mod " .. mod.id .. " test: " .. tn .. ": " .. tostring(res)
+      local res = tt (mod) or false ---@type boolean
+      vim.print (
+        "Testing mod " .. mod.id .. " test: " .. tn .. ": " .. tostring (res)
       )
       return res
     end)

--- a/lua/down/event/init.lua
+++ b/lua/down/event/init.lua
@@ -1,34 +1,34 @@
-local log = require("down.log")
+local log = require ("down.log")
 
 ---@class down.Event
 local Event = {
-  autocmd = require("down.event.autocmd"),
+  autocmd = require ("down.event.autocmd"),
   id = "",
   ref = "",
   split = {},
   body = nil,
   broadcast = true,
-  position = vim.api.nvim_win_get_cursor(0),
-  file = vim.fn.expand("%:p"),
-  dir = vim.fn.getcwd(),
-  buf = vim.api.nvim_get_current_buf(),
-  win = vim.api.nvim_get_current_win(),
-  mode = vim.fn.mode(),
-  line = vim.api.nvim_win_get_cursor(0)[1],
-  char = vim.api.nvim_win_get_cursor(0)[2],
+  position = vim.api.nvim_win_get_cursor (0),
+  file = vim.fn.expand ("%:p"),
+  dir = vim.fn.getcwd (),
+  buf = vim.api.nvim_get_current_buf (),
+  win = vim.api.nvim_get_current_win (),
+  mode = vim.fn.mode (),
+  line = vim.api.nvim_win_get_cursor (0)[1],
+  char = vim.api.nvim_win_get_cursor (0)[2],
   ---@type down.Context
   context = {
     ---@type down.Position
     position = {
-      line = vim.api.nvim_win_get_cursor(0)[1],
-      char = vim.api.nvim_win_get_cursor(0)[2],
+      line = vim.api.nvim_win_get_cursor (0)[1],
+      char = vim.api.nvim_win_get_cursor (0)[2],
     },
-    line = vim.api.nvim_get_current_line(),
-    char = vim.api.nvim_win_get_cursor(0)[2],
-    file = vim.fn.expand("%:p"),
-    buf = vim.api.nvim_get_current_buf(),
-    win = vim.api.nvim_get_current_win(),
-    dir = vim.fn.getcwd(),
+    line = vim.api.nvim_get_current_line (),
+    char = vim.api.nvim_win_get_cursor (0)[2],
+    file = vim.fn.expand ("%:p"),
+    buf = vim.api.nvim_get_current_buf (),
+    win = vim.api.nvim_get_current_win (),
+    dir = vim.fn.getcwd (),
     scope = "global",
   },
 }
@@ -46,7 +46,7 @@ local Callback = {
 
 --- @param ty? string
 --- @return { [1]: fun(event: down.Event, content: table|any) }
-function Event:get_cb(ty)
+function Event:get_cb (ty)
   return Callback.cb[ty or self.id]
 end
 
@@ -54,27 +54,27 @@ end
 --- @param self down.Event | string
 --- @param cb fun(event: down.Event, content: table|any) The function to call whenever our event gets triggered.
 --- @param filt? fun(event: down.Event): boolean # A filtering function to test if a certain event meets our expectations.
-function Event.callback(self, cb, filt)
+function Event.callback (self, cb, filt)
   local ty = (self and self.id) or self
   Callback.cb[ty] = Callback.cb[ty] or {}
-  table.insert(Callback.cb[ty], { cb, filt })
+  table.insert (Callback.cb[ty], { cb, filt })
 end
 
 --- @param cb? fun(event: down.Event, content: table|any)
-function Event.set_callback(self, cb)
+function Event.set_callback (self, cb)
   Callback.cb[self.id] = Callback.cb[self.id] or {}
-  table.insert(Callback.cb[self.id], cb)
+  table.insert (Callback.cb[self.id], cb)
 end
 
 --- Used internally by down to call all C with an event.
 --- @param self down.Event
-function Event.handle(self)
-  log.trace("Event.handle: Handling ", self.id)
+function Event.handle (self)
+  log.trace ("Event.handle: Handling ", self.id)
   local cbentry = Callback.cb[self.id]
   if cbentry then
-    for _, cb in ipairs(cbentry) do
-      if not cb[2] or cb[2](self) then
-        cb[1](self, self.body)
+    for _, cb in ipairs (cbentry) do
+      if not cb[2] or cb[2] (self) then
+        cb[1] (self, self.body)
       end
     end
   end
@@ -82,11 +82,11 @@ end
 
 --- Load callback
 --- @param m down.Mod.Mod
-function Event.load_callback(m)
-  for hk, ht in pairs(m.handle) do
-    for ck, ct in pairs(ht) do
-      if type(ct) == "function" then
-        Event.callback(Event.define(m, ck), ct)
+function Event.load_callback (m)
+  for hk, ht in pairs (m.handle) do
+    for ck, ct in pairs (ht) do
+      if type (ct) == "function" then
+        Event.callback (Event.define (m, ck), ct)
       end
     end
   end
@@ -97,27 +97,27 @@ end
 ---@param name string The name of the event
 ---@param body any? The body payload
 ---@return down.Event event The result event
-Event.define = function(module, name, body)
+Event.define = function (module, name, body)
   local mn = ""
-  if type(module) == "table" then
+  if type (module) == "table" then
     mn = module.id
-  elseif type(module) == "string" then
+  elseif type (module) == "string" then
     mn = module
   end
   local id = mn .. ".events." .. name
   return { ---@type down.Event
     id = id,
     ref = mn,
-    split = Event.split_id(id) or {},
+    split = Event.split_id (id) or {},
     body = body or module,
     broadcast = true,
-    position = vim.api.nvim_win_get_cursor(0),
-    file = vim.fn.expand("%:p"),
-    dir = vim.fn.getcwd(),
-    line = vim.api.nvim_get_current_line(),
-    buf = vim.api.nvim_get_current_buf(),
-    win = vim.api.nvim_get_current_win(),
-    mode = vim.fn.mode(),
+    position = vim.api.nvim_win_get_cursor (0),
+    file = vim.fn.expand ("%:p"),
+    dir = vim.fn.getcwd (),
+    line = vim.api.nvim_get_current_line (),
+    buf = vim.api.nvim_get_current_buf (),
+    win = vim.api.nvim_get_current_win (),
+    mode = vim.fn.mode (),
     context = nil,
   }
 end
@@ -125,11 +125,11 @@ end
 --- Split id
 --- @param id string The full path of a init event
 --- @return string[]? splitid id
-function Event.split_id(id)
-  local sa, sb = id:find("%.events%.")
-  local sp_id = { id:sub(0, sa - 1), id:sub(sb + 1) }
+function Event.split_id (id)
+  local sa, sb = id:find ("%.events%.")
+  local sp_id = { id:sub (0, sa - 1), id:sub (sb + 1) }
   if #sp_id ~= 2 then
-    log.warn("Invalid type name:" .. id)
+    log.warn ("Invalid type name:" .. id)
     return
   end
   return sp_id
@@ -139,15 +139,15 @@ end
 --- @param m down.Mod.Mod A reference to the init invoking the function
 --- @param id string A full path to a valid event type (e.g. `init.events.some_event`)
 --- @return down.Event?
-function Event.get_event(m, id)
-  local split = Event.split_id(id)
+function Event.get_event (m, id)
+  local split = Event.split_id (id)
   if not split then
-    log.warn(
+    log.warn (
       "Unable to get event template for event" .. id .. "and init" .. m.id
     )
     return
   end
-  log.trace("Returning" .. split[2] .. "for init" .. split[1])
+  log.trace ("Returning" .. split[2] .. "for init" .. split[1])
   return m.events[split[2]]
 end
 
@@ -157,24 +157,24 @@ end
 --- @param body table|any? The body of the event, can be anything from a string to a table to whatever you please.
 --- @param ev? table The original event data.
 --- @return down.Event? # New event.
-function Event.new(m, id, body, ev)
-  local event_template = Event.get_event(m or { id = m.id }, id)
+function Event.new (m, id, body, ev)
+  local event_template = Event.get_event (m or { id = m.id }, id)
   if not event_template then
-    log.warn("Unable to create event of type" .. id .. ". Returning nil...")
+    log.warn ("Unable to create event of type" .. id .. ". Returning nil...")
     return
   end
-  local mn = vim.deepcopy(event_template)
+  local mn = vim.deepcopy (event_template)
   mn.id = id
   mn.body = body
   mn.ref = m.id
-  mn.split = assert(Event.split_id(id))
-  mn.file = vim.fn.expand("%:t") --[[@as string]]
-  mn.dir = vim.fn.expand("%:p:h") --[[@as string]]
-  mn.buf = ev and ev.buf or vim.api.nvim_get_current_buf()
-  mn.win = vim.api.nvim_get_current_win()
-  mn.position = vim.api.nvim_win_get_cursor(mn.win)
-  mn.mode = vim.api.nvim_get_mode()
-  mn.line = vim.api.nvim_buf_get_lines(
+  mn.split = assert (Event.split_id (id))
+  mn.file = vim.fn.expand ("%:t") --[[@as string]]
+  mn.dir = vim.fn.expand ("%:p:h") --[[@as string]]
+  mn.buf = ev and ev.buf or vim.api.nvim_get_current_buf ()
+  mn.win = vim.api.nvim_get_current_win ()
+  mn.position = vim.api.nvim_win_get_cursor (mn.win)
+  mn.mode = vim.api.nvim_get_mode ()
+  mn.line = vim.api.nvim_buf_get_lines (
     mn.buf,
     mn.position[1] - 1,
     mn.position[1],
@@ -188,21 +188,21 @@ end
 --- @param mods down.Mod.Mod[]
 --- @param self down.Event
 --- @return nil
-function Event.broadcast_to(self, mods)
+function Event.broadcast_to (self, mods)
   if not self.split then
-    log.error(
+    log.error (
       "Unable to broadcast event of type" .. self.id .. "- invalid event name"
     )
     return
   end
-  Event.handle(self)
-  for mid, cm in pairs(mods or {}) do
+  Event.handle (self)
+  for mid, cm in pairs (mods or {}) do
     if cm.handle and cm.handle[self.split[1]] then
       local evt = cm.handle[self.split[1]][self.split[2]]
-      if evt == nil or type(evt) == "nil" then
+      if evt == nil or type (evt) == "nil" then
         goto broadcastcontinue
-      elseif type(evt) == "function" then
-        evt(self)
+      elseif type (evt) == "function" then
+        evt (self)
       end
     end
     ::broadcastcontinue::
@@ -213,13 +213,13 @@ end
 --- @param recv down.Mod.Mod The name of a loaded init that will be the recipient of the event.
 --- @return nil
 --- @param self down.Event
-function Event.send(self, recv)
+function Event.send (self, recv)
   self.broadcast = false
-  Event.handle(self)
+  Event.handle (self)
   if recv.handle and recv.handle[self.split[1]] then
     local evt = recv.handle[self.split[1]][self.split[2]]
-    if evt ~= nil and type(evt) == "function" then
-      evt(self)
+    if evt ~= nil and type (evt) == "function" then
+      evt (self)
     end
   end
 end

--- a/lua/down/health.lua
+++ b/lua/down/health.lua
@@ -2,114 +2,100 @@ local H = {}
 
 local h = vim.health
 local start = vim.health.start
-local ok, err, warn = h.ok, h.error, h.warn
 
-local config = require("down.config")
-local down = require("down")
+H.check = function ()
+  h.start ("down.nvim")
 
-H.cmds = function() end
-
-H.lsp = {
-  installed = function()
-    if vim.fn.executable("down.lsp") == 0 then
-      return h.error("down.lsp is not installed")
-    end
-    return h.ok("down.lsp is installed")
-  end,
-}
-
-H.user = function()
-  if config.user == nil then
-    return h.error("config.mod is nil")
-  end
-  return h.ok("config.mod is not nil")
-end
-
-H.workspace = function()
-  if config.user.workspace and config.user.workspace.workspaces == nil then
-    h.error("config.mod.workspace.workspaces is nil")
+  -- Check Neovim version
+  if vim.fn.has ("nvim-0.10") == 1 then
+    h.ok ("Neovim >= 0.10")
   else
-    h.ok("config.mod.workspace.workspaces is not nil")
+    h.error ("down.nvim requires Neovim >= 0.10")
+  end
+
+  -- Check plugin loaded
+  local ok, down = pcall (require, "down")
+  if ok then
+    h.ok ("down.nvim loaded successfully")
+  else
+    h.error ("Failed to load down.nvim: " .. tostring (down))
+    return
+  end
+
+  -- Check config
+  if down.config.started then
+    h.ok ("Plugin is initialized")
+  else
+    h.warn ("Plugin is not yet initialized (call require('down').setup())")
+  end
+
+  -- Check LSP
+  h.start ("down.lsp")
+  local lsp_ok, lsp_mod = pcall (require, "down.mod.lsp")
+  if lsp_ok and lsp_mod then
+    if lsp_mod.is_installed () then
+      h.ok ("down.lsp binary installed at: " .. lsp_mod.bin_path ())
+    else
+      h.warn ("down.lsp not installed (will auto-download on first use)")
+    end
+  else
+    h.warn ("LSP module not available")
+  end
+
+  -- Check MCP
+  h.start ("down.mcp")
+  local mcp_ok, mcp_mod = pcall (require, "down.mod.mcp")
+  if mcp_ok and mcp_mod then
+    if mcp_mod.is_installed () then
+      local running = mcp_mod.job_id and "running" or "stopped"
+      h.ok ("down.mcp binary installed (" .. running .. ")")
+    else
+      h.warn ("down.mcp not installed (will auto-download on first use)")
+    end
+  else
+    h.warn ("MCP module not available")
+  end
+
+  -- Check dependencies
+  h.start ("Dependencies")
+  local deps = {
+    { "nvim-treesitter", true },
+    { "telescope.nvim", false },
+    { "snacks.nvim", false },
+  }
+  for _, dep in ipairs (deps) do
+    local name, required = dep[1], dep[2]
+    local has = H.check_dep (name)
+    if has then
+      h.ok (name .. " installed")
+    elseif required then
+      h.error (name .. " is required but not installed")
+    else
+      h.info (name .. " not installed (optional)")
+    end
+  end
+
+  -- Check modules
+  h.start ("Modules")
+  local mod = require ("down.mod")
+  local loaded_count = vim.tbl_count (mod.mods)
+  if loaded_count > 0 then
+    h.ok (loaded_count .. " modules loaded")
+    for name, _ in pairs (mod.mods) do
+      h.info ("  • " .. name)
+    end
+  else
+    h.warn ("No modules loaded yet")
   end
 end
 
-H.deps = {
-  required = {
-    ["nvim-treesitter"] = "nvim-treesitter/nvim-treesitter",
-  },
-  optional = {
-    ["fzf.lua"] = "",
-    ["telescope.nvim"] = "nvim-telescope/telescope.nvim",
-    ["snacks.nvim"] = "folke/snacks.nvim",
-    ["mini.pick"] = "wuelnerdotexe/mini.pick",
-    ["nvim-web-devicons"] = "kyazdani42/nvim-web-devicons",
-    ["mini.icons"] = "wuelnerdotexe/mini.icons",
-  },
-  has_required = function()
-    for dep, repo in pairs(H.deps.required) do
-      if not H.check_dep(dep) then
-        return h.error(dep .. " is not installed" .. repo)
-      end
-    end
-    return h.ok("All required dependencies are installed")
-  end,
-}
-
-H.icon = {
-  ---@param provider? down.mod.ui.icon.Provider.Name
-  has_provider = function(provider)
-    if require("down.mod.ui.icon.util").has_provider(i) then
-      return h.ok("Icon provider is available " .. i)
-    end
-    return h.ok("Icon provider is not available, defaulting to builtin")
-  end,
-}
-
-H.check_dep = function(dep)
-  local lazyok, lazy = pcall(require, "lazy.core.config")
+H.check_dep = function (dep)
+  local lazyok, lazy = pcall (require, "lazy.core.config")
   if lazyok then
     return lazy.plugins[dep] ~= nil
   else
     return package.loaded[dep] ~= nil
   end
 end
-
-H.check_optional = function()
-  if H.check_dep("telescope.nvim") then
-    h.ok(H.optional["telescope.nvim"] .. " is installed")
-  else
-    h.warn(H.optional["telescope.nvim"] .. " is not installed")
-  end
-  if H.check_dep("nvim-web-devicons") or H.check_dep("mini.icons") then
-    h.warn(H.optional["mini.icons"] .. " is not installed")
-  else
-    h.warn(
-      H.optional["mini.icons"]
-        or H.optional["nvim-web-devicons"] .. " is not installed"
-    )
-  end
-end
-
-H.check_req = function()
-  for dep, repo in pairs(H.deps) do
-    if H.check_dep(dep) then
-      h.ok(dep .. " is installed" .. repo)
-    else
-      h.error(dep .. " is not installed" .. repo)
-    end
-  end
-end
-
-H.check = function()
-  h.start("down.nvim")
-  H.lsp.installed()
-  H.icon.has_provider("down")
-  H.check_optional()
-  H.check_req()
-  H.user()
-  H.workspace()
-end
-
-H.health = {}
 
 return H

--- a/lua/down/log/init.lua
+++ b/lua/down/log/init.lua
@@ -1,12 +1,12 @@
 ---@class down.Log
 local Log = {
   number_level = {
-    [0] = 'trace',
-    [1] = 'debug',
-    [2] = 'info',
-    [3] = 'warn',
-    [4] = 'error',
-    [5] = 'fatal',
+    [0] = "trace",
+    [1] = "debug",
+    [2] = "info",
+    [3] = "warn",
+    [4] = "error",
+    [5] = "fatal",
   },
   levels = {
     trace = 0,
@@ -17,7 +17,7 @@ local Log = {
     fatal = 5,
   },
   config = {
-    plugin = plug or 'down',
+    plugin = plug or "down",
 
     use_console = false,
 
@@ -25,19 +25,23 @@ local Log = {
 
     use_file = true,
 
-    level = 'trace',
+    level = "trace",
 
-    outfile = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', { 'data' }), 'down'),
+    outfile = string.format (
+      "%s/%s.log",
+      vim.api.nvim_call_function ("stdpath", { "data" }),
+      "down"
+    ),
     ---@type number
     lvl = vim.log.levels.TRACE,
 
     modes = {
-      trace = { hl = 'Comment', level = vim.log.levels.TRACE },
-      debug = { hl = 'Comment', level = vim.log.levels.DEBUG },
-      info = { hl = 'None', level = vim.log.levels.INFO },
-      warn = { hl = 'WarningMsg', level = vim.log.levels.WARN },
-      error = { hl = 'ErrorMsg', level = vim.log.levels.ERROR },
-      fatal = { hl = 'ErrorMsg', level = 5 },
+      trace = { hl = "Comment", level = vim.log.levels.TRACE },
+      debug = { hl = "Comment", level = vim.log.levels.DEBUG },
+      info = { hl = "None", level = vim.log.levels.INFO },
+      warn = { hl = "WarningMsg", level = vim.log.levels.WARN },
+      error = { hl = "ErrorMsg", level = vim.log.levels.ERROR },
+      fatal = { hl = "ErrorMsg", level = 5 },
     },
 
     float_precision = 0.01,
@@ -46,120 +50,122 @@ local Log = {
 
 -- local unpack = unpack or table.unpack
 
-Log.debug = function(...)
-  Log.at_level('debug', Log.config.modes['debug'], Log.format, ...)
+Log.debug = function (...)
+  Log.at_level ("debug", Log.config.modes["debug"], Log.format, ...)
 end
-Log.warn = function(...)
-  Log.at_level('warn', Log.config.modes['warn'], Log.format, ...)
+Log.warn = function (...)
+  Log.at_level ("warn", Log.config.modes["warn"], Log.format, ...)
 end
-Log.info = function(...)
-  Log.at_level('info', Log.config.modes['info'], Log.format, ...)
+Log.info = function (...)
+  Log.at_level ("info", Log.config.modes["info"], Log.format, ...)
 end
-Log.error = function(...)
-  Log.at_level('error', Log.config.modes['error'], Log.format, ...)
+Log.error = function (...)
+  Log.at_level ("error", Log.config.modes["error"], Log.format, ...)
 end
-Log.fatal = function(...)
-  Log.at_level('fatal', Log.config.modes['fatal'], Log.format, ...)
+Log.fatal = function (...)
+  Log.at_level ("fatal", Log.config.modes["fatal"], Log.format, ...)
 end
-Log.trace = function(...)
-  Log.at_level('trace', Log.config.modes['trace'], Log.format, ...)
+Log.trace = function (...)
+  Log.at_level ("trace", Log.config.modes["trace"], Log.format, ...)
 end
 
-Log.at_level = function(level, level_config, message_maker, ...)
+Log.at_level = function (level, level_config, message_maker, ...)
   if Log.levels[level] < Log.levels[Log.config.level] then
     return
   end
-  local nameupper = level:upper()
+  local nameupper = level:upper ()
 
-  local msg = message_maker(...)
-  local info = debug.getinfo(2, 'Sl')
-  local lineinfo = info.short_src .. ':' .. info.currentline
+  local msg = message_maker (...)
+  local info = debug.getinfo (2, "Sl")
+  local lineinfo = info.short_src .. ":" .. info.currentline
 
   -- Output to console
   if Log.config.use_console then
-    local v = string.format('(%s)\n%s\n%s', os.date('%H:%M:%S'), lineinfo, msg)
+    local v =
+      string.format ("(%s)\n%s\n%s", os.date ("%H:%M:%S"), lineinfo, msg)
 
     if Log.config.highlights and level_config.hl then
-      (vim.schedule_wrap(function()
-        vim.cmd(string.format('echohl %s', level_config.hl))
-      end))()
+      (vim.schedule_wrap (function ()
+        vim.cmd (string.format ("echohl %s", level_config.hl))
+      end)) ()
     end
 
-    (vim.schedule_wrap(function()
-      vim.notify(
-        string.format('[%s] %s', Log.config.plugin, vim.fn.escape(v, '"')),
+    (vim.schedule_wrap (function ()
+      vim.notify (
+        string.format ("[%s] %s", Log.config.plugin, vim.fn.escape (v, '"')),
         level_config.level
       )
       -- vim.cmd(string.format([[echom [%s] %s]], Log.config.plugin, vim.fn.escape(v, '"')))
-    end))()
+    end)) ()
 
     if Log.config.highlights and level_config.hl then
-      (vim.schedule_wrap(function()
-        vim.cmd('echohl NONE')
-      end))()
+      (vim.schedule_wrap (function ()
+        vim.cmd ("echohl NONE")
+      end)) ()
     end
   end
 
   -- Output to log file
   if Log.config.use_file then
-    local fp = assert(io.open(Log.config.outfile, 'a'))
-    local str = string.format('[%-6s%s] %s: %s\n', nameupper, os.date(), lineinfo, msg)
-    fp:write(str)
-    fp:close()
+    local fp = assert (io.open (Log.config.outfile, "a"))
+    local str =
+      string.format ("[%-6s%s] %s: %s\n", nameupper, os.date (), lineinfo, msg)
+    fp:write (str)
+    fp:close ()
   end
 end
-Log.round = function(x, increment)
+Log.round = function (x, increment)
   increment = increment or 1
   x = x / increment
-  return (x > 0 and math.floor(x + 0.5) or math.ceil(x - 0.5)) * increment
+  return (x > 0 and math.floor (x + 0.5) or math.ceil (x - 0.5)) * increment
 end
 
-Log.format = function(...)
+Log.format = function (...)
   local t = {}
-  for i = 1, select('#', ...) do
-    local x = select(i, ...)
+  for i = 1, select ("#", ...) do
+    local x = select (i, ...)
 
-    if type(x) == 'number' and Log.config.float_precision then
-      x = tostring(Log.round(x, Log.config.float_precision))
-    elseif type(x) == 'table' then
-      x = vim.inspect(x)
+    if type (x) == "number" and Log.config.float_precision then
+      x = tostring (Log.round (x, Log.config.float_precision))
+    elseif type (x) == "table" then
+      x = vim.inspect (x)
     else
-      x = tostring(x)
+      x = tostring (x)
     end
 
     t[#t + 1] = x
   end
-  return table.concat(t, ' ')
+  return table.concat (t, " ")
 end
-function Log.log(...)
+function Log.log (...)
   local passed = { ... }
-  local fmt = table.remove(passed, 1)
+  local fmt = table.remove (passed, 1)
   local inspected = {}
-  for _, v in ipairs(passed) do
-    table.insert(inspected, vim.inspect(v))
+  for _, v in ipairs (passed) do
+    table.insert (inspected, vim.inspect (v))
   end
-  return string.format(fmt, table.unpack(inspected))
+  return string.format (fmt, table.unpack (inspected))
 end
 
 --- @param cfg down.log.Config
 --- @param standalone boolean
-Log.new = function(cfg, standalone)
-  cfg = vim.tbl_extend('force', cfg, Log.config)
-  cfg.plugin = 'down' -- Force the plugin name to be down
+Log.new = function (cfg, standalone)
+  cfg = vim.tbl_extend ("force", cfg, Log.config)
+  cfg.plugin = "down" -- Force the plugin name to be down
   Log.config = cfg
-  for m, v in ipairs(cfg.modes) do
+  for m, v in ipairs (cfg.modes) do
     Log.levels[m] = v.level
   end
 
   local obj = standalone ~= nil and Log or {}
 
-  for m, x in ipairs(cfg.modes) do
-    obj[m] = function(...)
-      return Log.at_level(m, x, Log.format, ...)
+  for m, x in ipairs (cfg.modes) do
+    obj[m] = function (...)
+      return Log.at_level (m, x, Log.format, ...)
     end
 
-    obj[('fmt_%s'):format(m)] = function(...)
-      return Log.at_level(m, x, Log.log, ...)
+    obj[("fmt_%s"):format (m)] = function (...)
+      return Log.at_level (m, x, Log.log, ...)
     end
   end
 end

--- a/lua/down/mod.lua
+++ b/lua/down/mod.lua
@@ -1,12 +1,12 @@
-local Event = require("down.event")
-local modutil = require("down.mod.util")
-local util = require("down.util")
-local log = log
+local Event = require ("down.event")
+local log = require ("down.log")
+local modutil = require ("down.mod.util")
+local util = require ("down.util")
 
 --- The Mod class is the core of the down plugin system. It is responsible for loading, unloading, and managing the lifecycle of all modules.
 ---@class down.mod.Root: down.Mod
-local Mod = setmetatable({
-  setup = function()
+local Mod = setmetatable ({
+  setup = function ()
     return {
       loaded = true,
       replaces = {},
@@ -14,10 +14,10 @@ local Mod = setmetatable({
       dependencies = {},
     }
   end,
-  load = function()
+  load = function ()
     -- print 'default load n'
   end,
-  after = function()
+  after = function ()
     -- print('postload' .. n)
   end,
   opts = {},
@@ -26,49 +26,49 @@ local Mod = setmetatable({
   commands = {},
   handle = {},
   id = "",
-  namespace = vim.api.nvim_create_namespace("down.mod"),
+  namespace = vim.api.nvim_create_namespace ("down.mod"),
   config = {},
   events = {},
   dep = {},
   import = {},
   tests = {},
 }, {
-  __eq = function(m1, m2)
+  __eq = function (m1, m2)
     return m1.id == m2.id
   end,
-  __tostring = function(self)
+  __tostring = function (self)
     return self.id or ""
   end,
-  __concat = function(self, b)
+  __concat = function (self, b)
     return self.id .. b.id
   end,
   ---@param id? string
   ---@param self down.Mod.Mod
   ---@return down.Mod
-  __call = function(self, id, config)
+  __call = function (self, id, config)
     if id then
       self.id = id or ""
-      self.namespace = vim.api.nvim_create_namespace("down.mod." .. id)
-      self.load_mod(id, config or {})
+      self.namespace = vim.api.nvim_create_namespace ("down.mod." .. id)
+      self.load_mod (id, config or {})
     end
   end,
 })
 
-Mod.check_id = function(id)
-  return modutil.check_id(id)
+Mod.check_id = function (id)
+  return modutil.check_id (id)
 end
 
 Mod.metatable = {
   ---@type metatable
   handle = {
-    __index = function(self, k)
-      if type(k) == "table" then
+    __index = function (self, k)
+      if type (k) == "table" then
         if k.split then
           return self[k.split[1]][k.split[2]]
         end
         return self[k[1]][k[2]]
-      elseif type(k) == "string" then
-        local ks = string.split(k, "%.")
+      elseif type (k) == "string" then
+        local ks = string.split (k, "%.")
         if #ks == 1 then
           return self[ks[1]]
         end
@@ -76,21 +76,21 @@ Mod.metatable = {
       end
       return self[k]
     end,
-    __newindex = function(self, k, v)
+    __newindex = function (self, k, v)
       self[k] = v
     end,
-    __call = function(self, e, ...)
+    __call = function (self, e, ...)
       if e then
-        if self[e] and type(self[e]) == "function" then
-          return self[e](e)
+        if self[e] and type (self[e]) == "function" then
+          return self[e] (e)
         end
-        return self[e](e)
+        return self[e] (e)
       end
-      return self(e)
+      return self (e)
     end,
   },
   ---@type metatable
-  mod = getmetatable(Mod),
+  mod = getmetatable (Mod),
 }
 
 --- The loaded mods table.
@@ -104,7 +104,7 @@ Mod.default = {
     "note",
     "workspace",
   },
-  setup = function()
+  setup = function ()
     return {
       loaded = true,
       replaces = {},
@@ -113,15 +113,15 @@ Mod.default = {
     }
   end,
   ---@return down.Mod
-  mod = function(n)
+  mod = function (n)
     ---@type down.Mod
-    return setmetatable({
-      setup = Mod.default.setup(),
+    return setmetatable ({
+      setup = Mod.default.setup (),
       commands = {},
-      load = function()
+      load = function ()
         -- print 'default load n'
       end,
-      after = function()
+      after = function ()
         -- print('postload' .. n)
       end,
       opts = {},
@@ -129,30 +129,30 @@ Mod.default = {
       -- handle = setmetatable({}, Mod..metatable.handle),
       handle = {},
       id = n,
-      namespace = vim.api.nvim_create_namespace("down.mod." .. n),
+      namespace = vim.api.nvim_create_namespace ("down.mod." .. n),
       config = {},
       events = {},
       dep = {},
       import = {},
       tests = {},
-    }, getmetatable(Mod))
+    }, getmetatable (Mod))
   end,
 }
 
 --- @param nm string
 --- @param im? string[]
-Mod.new = function(nm, im)
-  local n = Mod.default.mod(nm)
+Mod.new = function (nm, im)
+  local n = Mod.default.mod (nm)
   if im then
-    for _, imp in ipairs(im) do
-      local fp = table.concat({ nm, imp }, ".")
-      if not Mod.load_mod(fp) then
-        log.error(
+    for _, imp in ipairs (im) do
+      local fp = table.concat ({ nm, imp }, ".")
+      if not Mod.load_mod (fp) then
+        log.error (
           "Unable to load import '"
             .. fp
             .. "'! An error  (see traceback below):"
         )
-        assert(false)
+        assert (false)
       end
       -- n.import[fp] = Mod.mods[fp]
     end
@@ -162,29 +162,29 @@ end
 
 --- @param mod string
 ---@return nil
-Mod.delete = function(mod)
+Mod.delete = function (mod)
   Mod.mods[mod] = nil
 end
 
 --- @param m down.Mod.Mod The actual mod to load.
 --- @return down.Mod.Mod|nil # Whether the mod successfully loaded.
-Mod.from_table = function(m, cfg)
+Mod.from_table = function (m, cfg)
   if Mod.mods[m.id] ~= nil then
     return Mod.mods[m.id]
   end
   ---@type down.mod.Setup
-  local mod_load = m.setup and m.setup() or Mod.default.setup()
+  local mod_load = m.setup and m.setup () or Mod.default.setup ()
   ---@type down.Mod
   local mod_to_replace
   if mod_load.replaces and mod_load.replaces ~= "" then
-    mod_to_replace = vim.deepcopy(Mod.mods[mod_load.replaces])
+    mod_to_replace = vim.deepcopy (Mod.mods[mod_load.replaces])
   end
   Mod.mods[m.id] = m
-  if mod_load.dependencies and vim.tbl_count(mod_load.dependencies) then
-    for _, req in pairs(mod_load.dependencies) do
-      if not Mod.is_loaded(req) then
-        if not Mod.load_mod(req) then
-          return Mod.delete(m.id)
+  if mod_load.dependencies and vim.tbl_count (mod_load.dependencies) then
+    for _, req in pairs (mod_load.dependencies) do
+      if not Mod.is_loaded (req) then
+        if not Mod.load_mod (req) then
+          return Mod.delete (m.id)
         end
       end
       m.dep[req] = Mod.mods[req]
@@ -193,26 +193,26 @@ Mod.from_table = function(m, cfg)
   if mod_to_replace then
     m.id = mod_to_replace.id
     if mod_to_replace.replaced then
-      return Mod.delete(m.id)
+      return Mod.delete (m.id)
     end
     if mod_load.merge then
-      m = vim.tbl_deep_extend("force", m, mod_to_replace)
+      m = vim.tbl_deep_extend ("force", m, mod_to_replace)
     end
     m.replaced = true
   end
-  Mod.mod_load(m)
+  Mod.mod_load (m)
   return Mod.mods[m.id]
 end
 
 --- @param n string
 --- @return down.Mod.Mod
-function Mod.check_mod(n)
-  local modl = require("down.mod." .. n)
+function Mod.check_mod (n)
+  local modl = require ("down.mod." .. n)
   if not modl then
-    log.error("Mod.load_mod: could not load mod " .. n)
+    log.error ("Mod.load_mod: could not load mod " .. n)
     return nil
   elseif modl == true then
-    log.error("Mod.load_mod: could not load mod " .. n)
+    log.error ("Mod.load_mod: could not load mod " .. n)
     return nil
   end
   return modl
@@ -221,29 +221,29 @@ end
 --- @param modn string A path to a mod on disk. A path in down is '.', not '/'.
 --- @param cfg table? A config that reflects the structure of `down.config.user.setup["mod.id"].config`.
 --- @return down.Mod.Mod|nil # Whether the mod was successfully loaded.
-function Mod.load_mod(modn, cfg)
+function Mod.load_mod (modn, cfg)
   if Mod.mods[modn] then
     if cfg ~= nil then
-      Mod.mods[modn].config = util.extend(cfg or {}, Mod.mods[modn].config)
+      Mod.mods[modn].config = util.extend (cfg or {}, Mod.mods[modn].config)
     end
     return Mod.mods[modn]
   end
-  local modl = Mod.check_mod(modn)
+  local modl = Mod.check_mod (modn)
   if not modl then
     return nil
   end
-  if cfg and not vim.tbl_isempty(cfg) then
-    modl.config = util.extend(modl.config, cfg)
+  if cfg and not vim.tbl_isempty (cfg) then
+    modl.config = util.extend (modl.config, cfg)
   end
-  return Mod.from_table(modl)
+  return Mod.from_table (modl)
 end
 
 --- Returns the mod.config table if the mod is loaded
 --- @param modn string The name of the mod to retrieve (mod must be loaded)
 --- @return table?
-function Mod.mod_config(modn)
-  if not Mod.is_loaded(modn) then
-    log.trace(
+function Mod.mod_config (modn)
+  if not Mod.is_loaded (modn) then
+    log.trace (
       "Attempt to get mod config with name"
         .. modn
         .. "failed - mod is not loaded."
@@ -255,11 +255,11 @@ end
 
 --- Retrieves the public API exposed by the mod.
 --- @return down.Mod.Mod?
-function Mod.get_mod(modn)
-  if Mod.is_loaded(modn) then
+function Mod.get_mod (modn)
+  if Mod.is_loaded (modn) then
     return Mod.mods[modn]
   end
-  log.trace(
+  log.trace (
     "Attempt to get mod with name" .. modn .. "failed - mod is not loaded."
   )
 end
@@ -267,7 +267,7 @@ end
 --- Returns true if mod with name modn is loaded, false otherwise
 --- @param modn string The name of an arbitrary mod
 --- @return down.Mod|nil
-function Mod.is_loaded(modn)
+function Mod.is_loaded (modn)
   if Mod.mods[modn] ~= nil then
     return Mod.mods[modn]
   end
@@ -277,13 +277,13 @@ end
 --- Executes `callback` once `mod` is a valid and loaded mod, else the callback gets instantly executed.
 --- @param modn string The name of the mod to listen for.
 --- @param cb fun(mod_public_table: table)
-function Mod.await(modn, cb)
-  if Mod.is_loaded(modn) then
-    cb(assert(Mod.get_mod(modn)))
+function Mod.await (modn, cb)
+  if Mod.is_loaded (modn) then
+    cb (assert (Mod.get_mod (modn)))
   else
-    Event.callback("mod_loaded", function(_, m)
-      cb(m)
-    end, function(e)
+    Event.callback ("mod_loaded", function (_, m)
+      cb (m)
+    end, function (e)
       return e.body.id == modn
     end)
   end
@@ -291,87 +291,87 @@ end
 
 ---@field k table|function
 ---@field kt? function
-function Mod.load_kind(mk, kt)
-  if type(mk) == "function" then
-    mk()
-  elseif type(mk) == "nil" then
+function Mod.load_kind (mk, kt)
+  if type (mk) == "function" then
+    mk ()
+  elseif type (mk) == "nil" then
     return
-  elseif type(mk) == "table" then
-    for k, v in pairs(mk) do
-      kt(k, v)
+  elseif type (mk) == "table" then
+    for k, v in pairs (mk) do
+      kt (k, v)
     end
   end
 end
 
 --- Load the opts for the mod
 ---@param m down.Mod.Mod
-function Mod.load_opts(m)
-  Mod.load_kind(m.opts, function(k, v)
+function Mod.load_opts (m)
+  Mod.load_kind (m.opts, function (k, v)
     vim.bo[k] = v
   end)
 end
 
 --- Load the maps for the mod
 ---@param m down.Mod.Mod
-function Mod.load_maps(m)
-  Mod.load_kind(m.maps, function(_, v)
+function Mod.load_maps (m)
+  Mod.load_kind (m.maps, function (_, v)
     local opts = {
       noremap = true,
       nowait = true,
       silent = true,
     }
-    if type(v[4]) == "string" then
+    if type (v[4]) == "string" then
       opts.desc = v[4]
-    elseif type(v[4]) == "table" then
+    elseif type (v[4]) == "table" then
       opts = v[4]
-    elseif type(v[4]) == "nil" then
+    elseif type (v[4]) == "nil" then
       opts.desc = v[3] or ""
     end
-    vim.keymap.set(v[1] or "n", v[2], v[3], opts)
+    vim.keymap.set (v[1] or "n", v[2], v[3], opts)
   end)
 end
 
 --- Perform initialization for the mod
 ---@param m down.Mod.Mod
-function Mod.mod_load(m)
-  Mod.load_maps(m)
-  Mod.load_opts(m)
-  Event.load_callback(m)
+function Mod.mod_load (m)
+  Mod.load_maps (m)
+  Mod.load_opts (m)
+  Event.load_callback (m)
   if m.load then
-    m.load()
+    m.load ()
   end
 end
 
-Mod.get = function(m)
-  local ok, pc = pcall(require, "down.mod." .. m)
+Mod.get = function (m)
+  local ok, pc = pcall (require, "down.mod." .. m)
   if ok then
     return pc
   else
-    log.error("Mod.get: could not load mod " .. "down.mod." .. m)
+    log.error ("Mod.get: could not load mod " .. "down.mod." .. m)
     return nil
   end
 end
 --- @param ms? table<any, string> list of modules to load
 --- @return down.Mod.Mod[]
-Mod.modules = function(ms)
+Mod.modules = function (ms)
   local modmap = {}
-  for mname, module in pairs(ms or Mod.default.mods) do
-    modmap[mname] = Mod.load_mod(mname) or Mod.get(mname)
+  for mname, module in pairs (ms or Mod.default.mods) do
+    modmap[mname] = Mod.load_mod (mname) or Mod.get (mname)
   end
   return modmap
 end
 
 ---@param m down.Mod.Mod
-Mod.test = function(m)
-  log.info("Mod.test: Performing tests for ", m.id, ": ")
+Mod.test = function (m)
+  log.info ("Mod.test: Performing tests for ", m.id, ": ")
   if m.tests then
     for tn, test in m.tests do
-      log.info("Mod.test: Running test ", tn, " for ", m.id, ": ", test(m))
+      log.info ("Mod.test: Running test ", tn, " for ", m.id, ": ", test (m))
     end
   end
 end
 
-Mod.util = require("down.mod.util")
+Mod.util = require ("down.mod.util")
 
 --- Unloaded modules
 --- @alias down.mod.Unloaded down.Mod.Id[]
@@ -380,16 +380,16 @@ Mod.unloaded = modutil.ids
 --- Unload the module m
 --- @param m down.Mod.Id
 --- @return nil
-Mod.unload = function(m)
-  local old = vim.deepcopy(Mod.mods[m])
+Mod.unload = function (m)
+  local old = vim.deepcopy (Mod.mods[m])
   if old ~= nil then
     Mod.mods[m] = nil
     return old
   else
-    if Mod.check_id(m) then
-      log.warn("Mod.unload: Attempt to unload unloaded mod ", m)
+    if Mod.check_id (m) then
+      log.warn ("Mod.unload: Attempt to unload unloaded mod ", m)
     else
-      log.error("Mod.unload: Attempt to unload invalid mod ", m)
+      log.error ("Mod.unload: Attempt to unload invalid mod ", m)
     end
   end
 end
@@ -397,16 +397,16 @@ end
 --- Reload the module m
 --- @param m down.Mod.Id
 --- @return nil
-Mod.reload = function(m)
-  Mod.unload(m)
-  Mod.load_mod(m)
+Mod.reload = function (m)
+  Mod.unload (m)
+  Mod.load_mod (m)
 end
 
 --- Syncs the unloaded modules with the loaded modules
-Mod.sync = function()
-  for _, i in ipairs(Mod.util.ids) do
-    if not vim.list_contains(vim.tbl_keys(Mod.mods), i) then
-      Mod.unloaded[i] = Mod.get(i)
+Mod.sync = function ()
+  for _, i in ipairs (Mod.util.ids) do
+    if not vim.list_contains (vim.tbl_keys (Mod.mods), i) then
+      Mod.unloaded[i] = Mod.get (i)
     end
   end
 end
@@ -418,9 +418,9 @@ Mod.sync_unloaded = Mod.sync
 ---@param e down.Event
 ---@param cmd string
 ---@return boolean
-Mod.handle_cmd = function(self, e, cmd, cmds, ...)
-  log.trace("Mod.handle_cmd: Handling cmd ", cmd, " for mod ", self.id)
-  if not cmds or type(cmds) ~= "table" or not cmds[cmd] then
+Mod.handle_cmd = function (self, e, cmd, cmds, ...)
+  log.trace ("Mod.handle_cmd: Handling cmd ", cmd, " for mod ", self.id)
+  if not cmds or type (cmds) ~= "table" or not cmds[cmd] then
     return false
   end
   -- if cmds.enabled ~= nil and cmds.enabled == false then
@@ -440,10 +440,10 @@ Mod.handle_cmd = function(self, e, cmd, cmds, ...)
     if not self.handle["cmd"][cmd] then
       self.handle["cmd"][cmd] = cc.callback
     end
-    cc.callback(e)
+    cc.callback (e)
     return true
   elseif cc.commands then
-    return Mod.handle_cmd(self, e, cmd, cc.commands, ...)
+    return Mod.handle_cmd (self, e, cmd, cc.commands, ...)
   end
   return false
 end
@@ -453,17 +453,17 @@ end
 --- @param self down.Mod.Mod
 --- @param ... any
 --- @return boolean
-Mod.handle_event = function(self, e, ...)
-  log.trace("Mod.handle_event: Handling event ", e.id, " for mod ", self.id)
+Mod.handle_event = function (self, e, ...)
+  log.trace ("Mod.handle_event: Handling event ", e.id, " for mod ", self.id)
   if
     self.handle
     and self.handle[e.split[1]]
     and self.handle[e.split[1]][e.split[2]]
   then
-    self.handle[e.split[1]][e.split[2]](e)
+    self.handle[e.split[1]][e.split[2]] (e)
     return true
   elseif e.split[1] == "cmd" then
-    return Mod.handle_cmd(self, e, e.split[2], self.commands, ...)
+    return Mod.handle_cmd (self, e, e.split[2], self.commands, ...)
   end
   return false
 end
@@ -473,23 +473,23 @@ end
 --- @param body table
 --- @param ev? table
 --- @return down.Event?
-function Mod.new_event(m, id, body, ev)
-  return Event.new(m, id, body, ev)
+function Mod.new_event (m, id, body, ev)
+  return Event.new (m, id, body, ev)
 end
 
 ---@type fun(module: down.Mod.Mod, id: string): down.Event
 ---@return down.Event
-function Mod.define_event(module, nid)
-  return Event.define(module, nid)
+function Mod.define_event (module, nid)
+  return Event.define (module, nid)
 end
 
 ---@param e down.Event
-function Mod.broadcast(e)
-  Event.handle(e)
-  log.trace("Mod.broadcast: Broadcasting event", e.id)
-  for mn, m in pairs(Mod.mods) do
-    if Mod.handle_event(m, e) then
-      log.trace("Mod.broadcast: Broadcast success: ", e.id, " to mod ", mn)
+function Mod.broadcast (e)
+  Event.handle (e)
+  log.trace ("Mod.broadcast: Broadcasting event", e.id)
+  for mn, m in pairs (Mod.mods) do
+    if Mod.handle_event (m, e) then
+      log.trace ("Mod.broadcast: Broadcast success: ", e.id, " to mod ", mn)
     end
   end
 end
@@ -498,15 +498,15 @@ end
 --- @param self down.Mod.Mod A reference to the mod invoking the function
 --- @param id string A full path to a valid event type (e.g. `mod.events.some_event`)
 --- @return down.Event?
-function Mod.get_event(self, id)
-  local split = Event.split_id(id)
+function Mod.get_event (self, id)
+  local split = Event.split_id (id)
   if not split then
-    log.warn(
+    log.warn (
       "Unable to get event template for event" .. id .. "and mod" .. self.id
     )
     return
   end
-  log.trace("Returning" .. split[2] .. "for mod" .. split[1])
+  log.trace ("Returning" .. split[2] .. "for mod" .. split[1])
   return self.events[split[2]]
 end
 

--- a/lua/down/mod/cmd/init.lua
+++ b/lua/down/mod/cmd/init.lua
@@ -1,22 +1,21 @@
-local down = require("down")
-local log = require("down.log")
-local mod = require("down.mod")
-local util = require("down.util")
+local log = require ("down.log")
+local mod = require ("down.mod")
+local util = require ("down.util")
 local api, bo, fn = vim.api, vim.bo, vim.fn
 
 ---@class down.mod.cmd.Cmd: down.Mod
-local Cmd = mod.new "cmd"
+local Cmd = mod.new ("cmd")
 
-Cmd.setup = function()
+Cmd.setup = function ()
   return { loaded = true, dependencies = {} }
 end
 
-Cmd.get_commands = function(m)
+Cmd.get_commands = function (m)
   local c = {}
   if m.commands then
-    if type(c) == "table" then
-      for cmd, cc in pairs(m.commands) do
-        if type(cc) == "table" then
+    if type (c) == "table" then
+      for cmd, cc in pairs (m.commands) do
+        if type (cc) == "table" then
           if c.enabled ~= false then
             c[cmd] = cc
           end
@@ -33,8 +32,8 @@ Cmd.commands = {
     name = "cmd",
     args = 0,
     max_args = 1,
-    callback = function(e)
-      log.trace("Cmd callback")
+    callback = function (e)
+      log.trace ("Cmd callback")
     end,
     commands = {
       add = {
@@ -42,62 +41,61 @@ Cmd.commands = {
         name = "cmd.add",
         args = 0,
         max_args = 1,
-        callback = function(e)
-          log.trace("Cmd add callback")
+        callback = function (e)
+          log.trace ("Cmd add callback")
         end,
       },
       edit = {
         name = "cmd.edit",
         args = 0,
         max_args = 1,
-        callback = function(e)
-          log.trace("Cmd edit callback")
+        callback = function (e)
+          log.trace ("Cmd edit callback")
         end,
       },
       remove = {
         name = "cmd.remove",
         args = 0,
         max_args = 1,
-        callback = function(e)
-          log.trace("Cmd remove callback")
+        callback = function (e)
+          log.trace ("Cmd remove callback")
         end,
       },
       update = {
         name = "cmd.update",
         args = 0,
         max_args = 1,
-        callback = function(e)
-          log.trace("Cmd update callback")
+        callback = function (e)
+          log.trace ("Cmd update callback")
         end,
       },
     },
   },
 }
-Cmd.cb = function(data)
+Cmd.cb = function (data)
   local args = data.fargs
-  local buf = api.nvim_get_current_buf()
+  local buf = api.nvim_get_current_buf ()
   local is_down = bo[buf].filetype == "markdown"
 
   local ref = { commands = Cmd.commands }
   local argument_index = 0
 
-  for i, cmd in ipairs(args) do
-    if not ref.commands or vim.tbl_isempty(ref.commands) then
+  for i, cmd in ipairs (args) do
+    if not ref.commands or vim.tbl_isempty (ref.commands) then
       break
     end
     ref = ref.commands[cmd]
     if not ref then
-      log.error(
-        ("Error when executing `:Down %s` - such a command does not exist!"):format(
-          table.concat(vim.list_slice(args, 1, i), " ")
+      log.error (
+        ("Error when executing `:Down %s` - such a command does not exist!"):format (
+          table.concat (vim.list_slice (args, 1, i), " ")
         )
       )
       return
-    elseif not Cmd.cond(ref.condition) then
-      log.error(
-        ("Error when executing `:Down %s` - the command is currently disabled. Some commands will only become available under certain conditions, e.g. being within a `.down` file!")
-        :format(
-          table.concat(vim.list_slice(args, 1, i), " ")
+    elseif not Cmd.cond (ref.condition) then
+      log.error (
+        ("Error when executing `:Down %s` - the command is currently disabled. Some commands will only become available under certain conditions, e.g. being within a `.down` file!"):format (
+          table.concat (vim.list_slice (args, 1, i), " ")
         )
       )
       return
@@ -119,15 +117,15 @@ Cmd.cb = function(data)
   end
 
   if #args == 0 or argument_count < ref.min_args then
-    local completions = Cmd.generate_completions(
+    local completions = Cmd.generate_completions (
       _,
-      table.concat({ "Down ", data.args, " " })
+      table.concat ({ "Down ", data.args, " " })
     ) or {}
-    Cmd.select_next_cmd_arg(data.args, completions)
+    Cmd.select_next_cmd_arg (data.args, completions)
     return
   elseif argument_count > ref.max_args then
-    log.error(
-      ("Error when executing `:down %s` - too many arguments supplied! The command expects %s argument%s."):format(
+    log.error (
+      ("Error when executing `:down %s` - too many arguments supplied! The command expects %s argument%s."):format (
         data.args,
         ref.max_args == 0 and "no" or ref.max_args,
         ref.max_args == 1 and "" or "s"
@@ -137,16 +135,15 @@ Cmd.cb = function(data)
   end
 
   if not ref.name then
-    log.error(
-      ("Error when executing `:down %s` - the ending command didn't have a `name` variable associated with it! This is an implementation error on the developer's side, so file a report to the author of the mod.")
-      :format(
+    log.error (
+      ("Error when executing `:down %s` - the ending command didn't have a `name` variable associated with it! This is an implementation error on the developer's side, so file a report to the author of the mod."):format (
         data.args
       )
     )
     return
   end
   if not Cmd.events[ref.name] then
-    Cmd.events[ref.name] = mod.define_event(Cmd, ref.name)
+    Cmd.events[ref.name] = mod.define_event (Cmd, ref.name)
     if ref.callback then
       if not Cmd.handle then
         Cmd.handle = {}
@@ -158,18 +155,18 @@ Cmd.cb = function(data)
     end
   end
 
-  local e = mod.new_event(
+  local e = mod.new_event (
     Cmd,
-    table.concat({ "cmd.events.", ref.name }),
-    vim.list_slice(args, argument_index + 1)
+    table.concat ({ "cmd.events.", ref.name }),
+    vim.list_slice (args, argument_index + 1)
   )
   if ref.callback then
-    log.trace("Cmd.cb: Running ", ref.name, " callback")
-    ref.callback(e)
+    log.trace ("Cmd.cb: Running ", ref.name, " callback")
+    ref.callback (e)
   else
-    log.trace("Cmd.cb: Running ", ref.name, " broadcast")
+    log.trace ("Cmd.cb: Running ", ref.name, " broadcast")
     -- Cmd.handle['cmd'][ref.name]
-    mod.broadcast(e)
+    mod.broadcast (e)
   end
 end
 --
@@ -276,8 +273,8 @@ end
 --   end
 -- end
 --
-Cmd.cond = function(condition, buf, is_down)
-  buf = buf or vim.api.nvim_get_current_buf()
+Cmd.cond = function (condition, buf, is_down)
+  buf = buf or vim.api.nvim_get_current_buf ()
   is_down = is_down or vim.bo[buf].filetype == "markdown"
   if condition == nil then
     return true
@@ -285,8 +282,8 @@ Cmd.cond = function(condition, buf, is_down)
   if condition == "markdown" and not is_down then
     return false
   end
-  if type(condition) == "function" then
-    return condition(buf, is_down)
+  if type (condition) == "function" then
+    return condition (buf, is_down)
   end
   return condition
 end
@@ -294,14 +291,14 @@ end
 --- This function returns all available commands to be used for the :down command
 ---@param _ nil #Placeholder variable
 ---@param command string #Supplied by nvim itself; the full typed out command
-Cmd.generate_completions = function(_, command)
-  local current_buf = vim.api.nvim_get_current_buf()
+Cmd.generate_completions = function (_, command)
+  local current_buf = vim.api.nvim_get_current_buf ()
   local is_down = vim.bo[current_buf].filetype == "markdown"
 
-  command = command:gsub("^%s*", "")
+  command = command:gsub ("^%s*", "")
 
-  local splitcmd = vim.list_slice(
-    vim.split(command, " ", {
+  local splitcmd = vim.list_slice (
+    vim.split (command, " ", {
       plain = true,
       trimempty = true,
     }),
@@ -314,9 +311,9 @@ Cmd.generate_completions = function(_, command)
   local last_valid_ref = ref
   local last_completion_level = 0
 
-  for _, cmd in ipairs(splitcmd) do
+  for _, cmd in ipairs (splitcmd) do
     -- if ref.enabled ~= nil and ref.enabled == false then return end
-    if not ref or not Cmd.cond(ref.condition, current_buf, is_down) then
+    if not ref or not Cmd.cond (ref.condition, current_buf, is_down) then
       break
     end
 
@@ -336,47 +333,47 @@ Cmd.generate_completions = function(_, command)
     return
   end
   if not last_valid_ref.commands and last_valid_ref.complete then
-    if type(last_valid_ref.complete) == "function" then
-      last_valid_ref.complete = last_valid_ref.complete(current_buf, is_down)
+    if type (last_valid_ref.complete) == "function" then
+      last_valid_ref.complete = last_valid_ref.complete (current_buf, is_down)
     end
 
-    if vim.endswith(command, " ") then
+    if vim.endswith (command, " ") then
       local completions = last_valid_ref.complete[#splitcmd - last_completion_level + 1]
-          or {}
+        or {}
 
-      if type(completions) == "function" then
-        completions = completions(current_buf, is_down) or {}
+      if type (completions) == "function" then
+        completions = completions (current_buf, is_down) or {}
       end
 
       return completions
     else
       local completions = last_valid_ref.complete[#splitcmd - last_completion_level]
-          or {}
+        or {}
 
-      if type(completions) == "function" then
-        completions = completions(current_buf, is_down) or {}
+      if type (completions) == "function" then
+        completions = completions (current_buf, is_down) or {}
       end
 
-      return vim.tbl_filter(function(key)
-        return key:find(splitcmd[#splitcmd])
+      return vim.tbl_filter (function (key)
+        return key:find (splitcmd[#splitcmd])
       end, completions)
     end
   end
 
   -- TODO: Fix `:down m <tab>` giving invalid completions
-  local keys = ref and vim.tbl_keys(ref.commands or {})
-      or (
-        vim.tbl_filter(function(key)
-          return key:find(splitcmd[#splitcmd])
-        end, vim.tbl_keys(last_valid_ref.commands or {}))
-      )
-  table.sort(keys)
+  local keys = ref and vim.tbl_keys (ref.commands or {})
+    or (
+      vim.tbl_filter (function (key)
+        return key:find (splitcmd[#splitcmd])
+      end, vim.tbl_keys (last_valid_ref.commands or {}))
+    )
+  table.sort (keys)
   do
     local commands = (ref and ref.commands or last_valid_ref.commands) or {}
 
-    return vim.tbl_filter(function(key)
-      if type(commands[key]) == "table" then
-        return Cmd.cond(commands[key].condition, current_buf, is_down)
+    return vim.tbl_filter (function (key)
+      if type (commands[key]) == "table" then
+        return Cmd.cond (commands[key].condition, current_buf, is_down)
       end
     end, keys)
   end
@@ -385,26 +382,26 @@ end
 --- Queries the user to select next argument
 ---@param qargs table #A string of arguments previously supplied to the down command
 ---@param choices table #all possible choices for the next argument
-Cmd.select_next_cmd_arg = function(qargs, choices)
-  local current = table.concat({ "Down ", qargs })
+Cmd.select_next_cmd_arg = function (qargs, choices)
+  local current = table.concat ({ "Down ", qargs })
 
   local query
 
-  if vim.tbl_isempty(choices) then
-    query = function(...)
-      vim.ui.input(...)
+  if vim.tbl_isempty (choices) then
+    query = function (...)
+      vim.ui.input (...)
     end
   else
-    query = function(...)
-      vim.ui.select(choices, ...)
+    query = function (...)
+      vim.ui.select (choices, ...)
     end
   end
 
-  query({
+  query ({
     prompt = current,
-  }, function(choice)
+  }, function (choice)
     if choice ~= nil then
-      vim.cmd(("%s %s"):format(current, choice))
+      vim.cmd (("%s %s"):format (current, choice))
     end
   end)
 end
@@ -412,41 +409,41 @@ end
 -- The table containing all the functions. This can get a tad complex so I recommend you read the wiki entry
 
 ---@param mod_name string #An absolute path to a loaded init with a mod.config.commands table following a valid structure
-Cmd.add_commands = function(mod_name)
-  local mod_config = mod.get_mod(mod_name)
+Cmd.add_commands = function (mod_name)
+  local mod_config = mod.get_mod (mod_name)
 
   if
-      not mod_config
-      or not mod_config.commands
-      or (
-        mod_config.commands.enabled ~= nil
-        and mod_config.commands.enabled == false
-      )
+    not mod_config
+    or not mod_config.commands
+    or (
+      mod_config.commands.enabled ~= nil
+      and mod_config.commands.enabled == false
+    )
   then
     return
   end
 
-  Cmd.commands = vim.tbl_extend("force", Cmd.commands, mod_config.commands)
+  Cmd.commands = vim.tbl_extend ("force", Cmd.commands, mod_config.commands)
 end
 
-Cmd.enabled = function(c)
-  return vim.iter(c):filter(function(v)
+Cmd.enabled = function (c)
+  return vim.iter (c):filter (function (v)
     return v.enabled == nil or (v.enabled ~= nil and v.enabled == true)
   end)
 end
 
 --- Recursively merges the provided table with the mod.config.commands table.
 ---@param f down.Command[] #A table that follows the mod.config.commands structure
-Cmd.add_commands_from_table = function(f)
-  vim.tbl_extend("force", Cmd.commands, f)
+Cmd.add_commands_from_table = function (f)
+  vim.tbl_extend ("force", Cmd.commands, f)
 end
 
 --- Rereads data from all mod and rebuild the list of available autocompletiinitinitons and commands
-Cmd.sync = function()
-  for mn, lm in pairs(mod.mods) do
-    for cn, c in pairs(lm.commands or {}) do
-      if type(c) == "table" then
-        Cmd.commands[cn] = vim.tbl_extend("force", Cmd.commands[cn] or {}, c)
+Cmd.sync = function ()
+  for mn, lm in pairs (mod.mods) do
+    for cn, c in pairs (lm.commands or {}) do
+      if type (c) == "table" then
+        Cmd.commands[cn] = vim.tbl_extend ("force", Cmd.commands[cn] or {}, c)
       end
     end
   end
@@ -454,12 +451,12 @@ end
 
 --- Defines a custom completion function to use for `base.cmd`.
 ---@param callback function
-Cmd.set_completion = function(callback)
+Cmd.set_completion = function (callback)
   Cmd.generate_completions = callback
 end
 
-Cmd.load = function()
-  vim.api.nvim_create_user_command("Down", Cmd.cb, {
+Cmd.load = function ()
+  vim.api.nvim_create_user_command ("Down", Cmd.cb, {
     desc = "The down command",
     range = 2,
     force = true,
@@ -473,8 +470,8 @@ end
 Cmd.config = {}
 ---@class cmd
 
-Cmd.after = function()
-  Cmd.sync()
+Cmd.after = function ()
+  Cmd.sync ()
 end
 
 return Cmd

--- a/lua/down/mod/data/init.lua
+++ b/lua/down/mod/data/init.lua
@@ -1,23 +1,23 @@
-local config = require("down.config")
-local log = require("down.log")
-local mod = require("down.mod")
+local config = require ("down.config")
+local log = require ("down.log")
+local mod = require ("down.mod")
 local api, fn, fs, uv = vim.api, vim.fn, vim.fs, (vim.uv or vim.loop)
 local stdp, join = fn.stdpath, fs.joinpath
 
 ---@class down.mod.data.Data: down.Dataod
-local Data = mod.new("data")
+local Data = mod.new ("data")
 
 ---@class down.mod.data.Data.Data
 Data.data = {}
 
 --- @return down.mod.Setup
-Data.setup = function()
-  api.nvim_create_autocmd("VimLeavePre", {
-    callback = function()
-      Data.flush()
+Data.setup = function ()
+  api.nvim_create_autocmd ("VimLeavePre", {
+    callback = function ()
+      Data.flush ()
     end,
   })
-  Data.sync()
+  Data.sync ()
   ---@type down.mod.Setup
   return {
     loaded = true,
@@ -25,72 +25,72 @@ Data.setup = function()
   }
 end
 
-Data.load = function() end
+Data.load = function () end
 
 ---@class down.mod..Config
 Data.config = {
-  path = stdp("data") .. "/down.json",
+  path = stdp ("data") .. "/down.json",
   dir = {
-    vim = join(stdp("data") or fn.expand("~/.local/share/nvim"), "down/"),
-    home = join(os.getenv("HODataE") or "~/", ".down/"),
+    vim = join (stdp ("data") or fn.expand ("~/.local/share/nvim"), "down/"),
+    home = join (os.getenv ("HOME") or "~/", ".down/"),
   },
   file = {
-    vim = join(
-      stdp("data") or fn.expand("~/.local/share/nvim"),
+    vim = join (
+      stdp ("data") or fn.expand ("~/.local/share/nvim"),
       "down/",
       "down.json"
     ),
-    home = join(os.getenv("HODataE") or "~/", ".down/", "down.json"),
+    home = join (os.getenv ("HOME") or "~/", ".down/", "down.json"),
   },
 }
 
 ---@param name string
 ---@type fun(name: string): metatable
 ---@return metatable
-Data.mt = function(name)
+Data.mt = function (name)
   ---@type metatable
   return {
     ---@param self down.Dataod.Dataod
-    __tostring = function(self)
+    __tostring = function (self)
       return name
     end,
     ---@param self down.Dataod.Dataod
-    __index = function(self, key)
+    __index = function (self, key)
       if not self[name .. "." .. key] then
         return
       end
-      if not B.dep.data.get(key) == self[key] then
-        B.dep.data.set(name .. "." .. key, self[key])
+      if not B.dep.data.get (key) == self[key] then
+        B.dep.data.set (name .. "." .. key, self[key])
       end
       return self[key]
     end,
     __name = name,
     ---@param self down.Dataod.Dataod
-    __newindex = function(self, key, val)
+    __newindex = function (self, key, val)
       self[key] = val
-      B.dep.data.set(name .. "." .. key, val)
+      B.dep.data.set (name .. "." .. key, val)
     end,
     ---@param a down.Dataod.Dataod
-    __concat = function(a, b)
-      if type(b) == "string" then
-        return tostring(a) .. "." .. b
+    __concat = function (a, b)
+      if type (b) == "string" then
+        return tostring (a) .. "." .. b
       end
-      return tostring(a) .. tostring(b)
+      return tostring (a) .. tostring (b)
     end,
     ---@param self down.Dataod.Dataod
     ---@param load? boolean
-    __call = function(self, load)
-      for key, val in pairs(self) do
+    __call = function (self, load)
+      for key, val in pairs (self) do
         if load then
-          self[key] = Data.data.get(name .. "." .. key)
+          self[key] = Data.data.get (name .. "." .. key)
         elseif
-            not Data.dep.data.get(name .. "." .. key)
-            or not Data.dep.data.get(name .. "." .. key) == val
+          not Data.dep.data.get (name .. "." .. key)
+          or not Data.dep.data.get (name .. "." .. key) == val
         then
-          Data.dep.data.set(name .. "." .. key, val)
+          Data.dep.data.set (name .. "." .. key, val)
         end
       end
-      Data.flush()
+      Data.flush ()
     end,
   }
 end
@@ -99,38 +99,38 @@ end
 ---@param name string
 ---@param t T
 ---@return T
-Data.tbl = function(name, t)
-  return setmetatable(t, Data.mt(name))
+Data.tbl = function (name, t)
+  return setmetatable (t, Data.mt (name))
 end
 
-Data.concat = function(p1, p2)
-  return table.concat({ p1, require("down.util").sep, p2 })
+Data.concat = function (p1, p2)
+  return table.concat ({ p1, require ("down.util").sep, p2 })
 end
 
 --- @param path string
 --- @param cond? fun(name: string, ends: string): boolean
 --- @return table<string>
-Data.files = function(path, cond)
+Data.files = function (path, cond)
   local f = {}
-  local dir = path or vim.fs.root(vim.fn.cwd(), ".down/")
-  for name, type in vim.fs.dir(dir) do
-    if type == "file" and cond or name:endswith(".md") then
-      table.insert(f, name)
-    elseif type == "directory" and not name:startswith(".") then
-      local fs = Data.get_files(Data.concat(path, name))
-      for _, v in ipairs(fs) do
-        table.insert(f, v)
+  local dir = path or vim.fs.root (vim.fn.cwd (), ".down/")
+  for name, type in vim.fs.dir (dir) do
+    if type == "file" and cond or name:endswith (".md") then
+      table.insert (f, name)
+    elseif type == "directory" and not name:startswith (".") then
+      local fs = Data.get_files (Data.concat (path, name))
+      for _, v in ipairs (fs) do
+        table.insert (f, v)
       end
     end
   end
 end
 
-Data.directory_map = function(path, callback)
-  for name, type in vim.fs.dir(path) do
+Data.directory_map = function (path, callback)
+  for name, type in vim.fs.dir (path) do
     if type == "directory" then
-      Data.directory_map(Data.concat(path, name), callback)
+      Data.directory_map (Data.concat (path, name), callback)
     else
-      callback(name, type, path)
+      callback (name, type, path)
     end
   end
 end
@@ -140,25 +140,29 @@ end
 ---@param new_path string #The new location. This function will not
 --- succeed if the directory already exists.
 ---@return boolean #If true, the directory copying succeeded
-Data.copy_directory = function(old_path, new_path)
-  local file_permissions = tonumber("744", 8)
-  local ok, err = vim.loop.fs_mkdir(new_path, file_permissions)
+Data.copy_directory = function (old_path, new_path)
+  local file_permissions = tonumber ("744", 8)
+  local ok, err = vim.loop.fs_mkdir (new_path, file_permissions)
 
   if not ok then
     return ok, err ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
   end
 
-  for name, type in vim.fs.dir(old_path) do
+  for name, type in vim.fs.dir (old_path) do
     if type == "file" then
-      ok, err =
-          vim.loop.fs_copyfile(Data.concat(old_path, name), Data.concat(new_path, name))
+      ok, err = vim.loop.fs_copyfile (
+        Data.concat (old_path, name),
+        Data.concat (new_path, name)
+      )
 
       if not ok then
         return ok, err ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
       end
-    elseif type == "directory" and not vim.endswith(new_path, name) then
-      ok, err =
-          Data.copy_directory(Data.concat(old_path, name), Data.concat(new_path, name))
+    elseif type == "directory" and not vim.endswith (new_path, name) then
+      ok, err = Data.copy_directory (
+        Data.concat (old_path, name),
+        Data.concat (new_path, name)
+      )
 
       if not ok then
         return ok, err ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
@@ -169,55 +173,58 @@ Data.copy_directory = function(old_path, new_path)
   return true, nil ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
 end
 --- Grabs the data present on disk and overwrites it with the data present in memory
-Data.sync = function()
-  local file = io.open(Data.config.path, "r")
+Data.sync = function ()
+  local file = io.open (Data.config.path, "r")
   if not file then
     return
   end
-  local content = file:read("*a")
-  file:close()
-  Data.data = vim.json.decode and vim.json.decode(content)
+  local content = file:read ("*a")
+  file:close ()
+  Data.data = vim.json.decode and vim.json.decode (content)
 end
 
 --- Stores a key-value pair in the store
 ---@param key string #The key to index in the store
 ---@param data any #The data to store at the specific key
-Data.put = function(key, data)
+Data.put = function (key, data)
   Data.data[key] = data
-  Data.flush()
+  Data.flush ()
 end
 
 Data.set = Data.put
 
 --- Removes a key from store
 ---@param key string #The name of the key to remove
-Data.del = function(key)
+Data.del = function (key)
   Data.data[key] = nil
 end
 
 --- Retrieves a key from the store
 ---@param key string #The name of the key to index
 ---@return any|table #The data present at the key, or an empty table
-Data.get = function(key)
+Data.get = function (key)
   return Data.data[key] or {}
 end
 
-Data.json = function(path)
+Data.json = function (path)
   local dir = Data.config.dir.home
-  local vim = Data.config.dir.vim
-  vim.fn.mkdir(dir, "p")
-  vim.fn.mkdir(vim, "p")
-  local f = io.open(path or Data.config.file.vim, "w")
-  f:write(vim.json.encode(Data.data))
+  local vimdir = Data.config.dir.vim
+  fn.mkdir (dir, "p")
+  fn.mkdir (vimdir, "p")
+  local f = io.open (path or Data.config.file.vim, "w")
+  if f then
+    f:write (vim.json.encode (Data.data))
+    f:close ()
+  end
 end
 --- Flushes the contents in memory to the location specified
-Data.flush = function(path)
-  local file = io.open(path or Data.config.path, "w")
+Data.flush = function (path)
+  local file = io.open (path or Data.config.path, "w")
   if not file then
     return
   end
-  file:write(vim.json.encode and vim.json.encode(Data.data))
-  file:close()
+  file:write (vim.json.encode and vim.json.encode (Data.data))
+  file:close ()
 end
 
 -- Data.handle = {}

--- a/lua/down/mod/data/knowledge/init.lua
+++ b/lua/down/mod/data/knowledge/init.lua
@@ -1,3 +1,306 @@
-local Knowledge = require("down.mod").new("data.knowledge")
+local log = require ("down.log")
+local mod = require ("down.mod")
+
+---@class down.mod.data.knowledge.Knowledge: down.Mod
+local Knowledge = mod.new ("data.knowledge")
+
+---@class down.mod.data.knowledge.Entity
+---@field id string
+---@field name string
+---@field kind string
+---@field file string
+---@field line number
+---@field relations string[]
+
+---@class down.mod.data.knowledge.Graph
+---@field entities table<string, down.mod.data.knowledge.Entity>
+---@field relations table<string, string[]>
+
+---@class down.mod.data.knowledge.Config
+Knowledge.config = {
+  --- Enable knowledge graph indexing
+  enabled = true,
+  --- Auto-index on workspace change
+  auto_index = true,
+  --- Entity kinds to extract
+  kinds = {
+    "person",
+    "concept",
+    "project",
+    "place",
+    "action",
+    "tag",
+  },
+  --- Patterns to extract entities from wiki-links
+  wiki_link_pattern = "%[%[(.-)%]%]",
+  --- Patterns to extract entities from tags
+  tag_pattern = "#([%w_%-]+)",
+}
+
+---@return down.mod.Setup
+Knowledge.setup = function ()
+  return {
+    loaded = true,
+    dependencies = { "data", "workspace" },
+  }
+end
+
+---@type down.mod.data.knowledge.Graph
+Knowledge.graph = {
+  entities = {},
+  relations = {},
+}
+
+--- Add an entity to the graph
+---@param entity down.mod.data.knowledge.Entity
+Knowledge.add_entity = function (entity)
+  Knowledge.graph.entities[entity.id] = entity
+end
+
+--- Add a relation between two entities
+---@param from string
+---@param to string
+Knowledge.add_relation = function (from, to)
+  if not Knowledge.graph.relations[from] then
+    Knowledge.graph.relations[from] = {}
+  end
+  table.insert (Knowledge.graph.relations[from], to)
+end
+
+--- Extract entities from a buffer
+---@param buf? number
+---@return down.mod.data.knowledge.Entity[]
+Knowledge.extract_entities = function (buf)
+  buf = buf or vim.api.nvim_get_current_buf ()
+  local entities = {}
+  local lines = vim.api.nvim_buf_get_lines (buf, 0, -1, false)
+  local file = vim.api.nvim_buf_get_name (buf)
+
+  for lnum, line in ipairs (lines) do
+    -- Extract wiki-links [[entity]]
+    for name in line:gmatch (Knowledge.config.wiki_link_pattern) do
+      local entity = {
+        id = name:lower ():gsub ("%s+", "-"),
+        name = name,
+        kind = "concept",
+        file = file,
+        line = lnum,
+        relations = {},
+      }
+      table.insert (entities, entity)
+    end
+
+    -- Extract tags #tag
+    for tag in line:gmatch (Knowledge.config.tag_pattern) do
+      local entity = {
+        id = "tag:" .. tag:lower (),
+        name = tag,
+        kind = "tag",
+        file = file,
+        line = lnum,
+        relations = {},
+      }
+      table.insert (entities, entity)
+    end
+  end
+
+  return entities
+end
+
+--- Index a single file into the knowledge graph
+---@param path string
+Knowledge.index_file = function (path)
+  local ok, lines = pcall (vim.fn.readfile, path)
+  if not ok then
+    return
+  end
+  local file_id = path:gsub ("[/\\]", "."):gsub ("%.md$", "")
+
+  for lnum, line in ipairs (lines) do
+    for name in line:gmatch (Knowledge.config.wiki_link_pattern) do
+      local entity = {
+        id = name:lower ():gsub ("%s+", "-"),
+        name = name,
+        kind = "concept",
+        file = path,
+        line = lnum,
+        relations = {},
+      }
+      Knowledge.add_entity (entity)
+      Knowledge.add_relation (file_id, entity.id)
+    end
+
+    for tag in line:gmatch (Knowledge.config.tag_pattern) do
+      local entity = {
+        id = "tag:" .. tag:lower (),
+        name = tag,
+        kind = "tag",
+        file = path,
+        line = lnum,
+        relations = {},
+      }
+      Knowledge.add_entity (entity)
+      Knowledge.add_relation (file_id, entity.id)
+    end
+  end
+end
+
+--- Index the entire workspace
+Knowledge.index_workspace = function ()
+  local ws = mod.get_mod ("workspace")
+  if not ws then
+    return
+  end
+  local files = ws.files (nil, "**/*.md")
+  if not files then
+    return
+  end
+  Knowledge.graph = { entities = {}, relations = {} }
+  for _, file in ipairs (files) do
+    Knowledge.index_file (file)
+  end
+  Knowledge.save ()
+  log.info (
+    "Knowledge graph indexed: "
+      .. vim.tbl_count (Knowledge.graph.entities)
+      .. " entities"
+  )
+end
+
+--- Save the knowledge graph to disk
+Knowledge.save = function ()
+  local data_mod = mod.get_mod ("data")
+  if data_mod then
+    data_mod.set ("knowledge.graph", Knowledge.graph)
+    data_mod.flush ()
+  end
+end
+
+--- Load the knowledge graph from disk
+Knowledge.restore = function ()
+  local data_mod = mod.get_mod ("data")
+  if data_mod then
+    local saved = data_mod.get ("knowledge.graph")
+    if saved and type (saved) == "table" and saved.entities then
+      Knowledge.graph = saved
+    end
+  end
+end
+
+--- Query the knowledge graph for entities matching a pattern
+---@param query string
+---@return down.mod.data.knowledge.Entity[]
+Knowledge.query = function (query)
+  local results = {}
+  local pattern = query:lower ()
+  for _, entity in pairs (Knowledge.graph.entities) do
+    if
+      entity.name:lower ():find (pattern, 1, true)
+      or entity.id:find (pattern, 1, true)
+    then
+      table.insert (results, entity)
+    end
+  end
+  return results
+end
+
+--- Get relations for an entity
+---@param entity_id string
+---@return string[]
+Knowledge.get_relations = function (entity_id)
+  return Knowledge.graph.relations[entity_id] or {}
+end
+
+Knowledge.commands = {
+  knowledge = {
+    name = "knowledge",
+    args = 0,
+    max_args = 1,
+    callback = function ()
+      Knowledge.index_workspace ()
+    end,
+    commands = {
+      index = {
+        name = "knowledge.index",
+        args = 0,
+        callback = function ()
+          Knowledge.index_workspace ()
+        end,
+      },
+      query = {
+        name = "knowledge.query",
+        args = 1,
+        callback = function (e)
+          local query = e.body and e.body[1] or ""
+          local results = Knowledge.query (query)
+          if #results == 0 then
+            vim.notify ("[down.nvim] No entities found for: " .. query)
+          else
+            local items = {}
+            for _, entity in ipairs (results) do
+              table.insert (
+                items,
+                string.format (
+                  "[%s] %s (%s:%d)",
+                  entity.kind,
+                  entity.name,
+                  entity.file,
+                  entity.line
+                )
+              )
+            end
+            vim.ui.select (
+              items,
+              { prompt = "Knowledge Graph Results" },
+              function (choice)
+                if choice then
+                  local idx = vim.fn.index (items, choice) + 1
+                  local entity = results[idx]
+                  if entity then
+                    vim.cmd ("edit " .. entity.file)
+                    vim.api.nvim_win_set_cursor (0, { entity.line, 0 })
+                  end
+                end
+              end
+            )
+          end
+        end,
+      },
+      stats = {
+        name = "knowledge.stats",
+        args = 0,
+        callback = function ()
+          local entities = Knowledge.graph.entities or {}
+          local relations = Knowledge.graph.relations or {}
+          local entity_count = vim.tbl_count (entities)
+          local relation_count = 0
+          for _, rels in pairs (relations) do
+            relation_count = relation_count + #rels
+          end
+          vim.notify (
+            string.format (
+              "[down.nvim] Knowledge Graph: %d entities, %d relations",
+              entity_count,
+              relation_count
+            )
+          )
+        end,
+      },
+    },
+  },
+}
+
+Knowledge.load = function ()
+  Knowledge.restore ()
+  if Knowledge.config.auto_index then
+    vim.api.nvim_create_autocmd ("BufWritePost", {
+      pattern = "*.md",
+      callback = function (ev)
+        Knowledge.index_file (ev.file)
+      end,
+      desc = "Index file into knowledge graph on save",
+    })
+  end
+end
 
 return Knowledge

--- a/lua/down/mod/data/time/init.lua
+++ b/lua/down/mod/data/time/init.lua
@@ -1,6 +1,5 @@
-local down = require("down")
-local util = down.util
-local mod = down.mod
+local util = require("down.util")
+local mod = require("down.mod")
 local u = require("down.mod.data.time.util")
 local re = vim.re
 

--- a/lua/down/mod/edit/cursor/init.lua
+++ b/lua/down/mod/edit/cursor/init.lua
@@ -1,7 +1,7 @@
 local mod = require("down.mod")
 local tbl = require("down.util.table")
 local util = require("down.util")
-local log = log
+local log = require("down.log")
 local ts = vim.treesitter
 local tuok, tu = pcall(require, "nvim-treesitter.ts_utils")
 

--- a/lua/down/mod/integration/init.lua
+++ b/lua/down/mod/integration/init.lua
@@ -1,6 +1,6 @@
 local mod = require("down.mod")
 local util = require("down.util")
-local log = log
+local log = require("down.log")
 
 ---TODO: imelement
 ---@class down.mod.Tool: down.Mod

--- a/lua/down/mod/integration/treesitter/init.lua
+++ b/lua/down/mod/integration/treesitter/init.lua
@@ -1,18 +1,15 @@
-local down = require "down"
 local config = require "down.config"
 local mod = require "down.mod"
 local util = require "down.util"
-local install = require "nvim-treesitter.install"
-local shell = require "nvim-treesitter.shell_command_selectors"
-local utils = require "nvim-treesitter.utils"
-local ntp = require "nvim-treesitter.parsers"
-local locals = require "nvim-treesitter.locals"
-local tsu_ok, tsu = pcall(require, "nvim-treesitter.ts_utils")
-local log = log
+local log = require("down.log")
 local ts = vim.treesitter
-local vt = vim.treesitter
-local q = vt.query
-local hi = vt.highlight
+
+-- Lazy-load treesitter dependencies
+local function get_ts_dep(name)
+  local ok, m = pcall(require, name)
+  if ok then return m end
+  return nil
+end
 
 ---@class down.mod.integration.Treesitter: down.Mod
 local Treesitter = mod.new "integration.treesitter"
@@ -70,20 +67,19 @@ Treesitter.heading_query = [[
              ]]
 
 Treesitter.setup = function()
-  return { loaded = tsu_ok }
+  local has_ts = get_ts_dep("nvim-treesitter.ts_utils") ~= nil
+  return { loaded = has_ts }
 end
 
 Treesitter.load = function()
-  -- mod.await("cmd", function(downcmd)
-  --   downcmd.add_commands_from_table({
-  --     treesitter = {
-  --       args = 0,
-  --       name = "treesitter",
-  --     },
-  --   })
-  -- end)
-
-  assert(tsu_ok, "Unable to load nvim-treesitter.ts_utils")
+  local tsu = get_ts_dep("nvim-treesitter.ts_utils")
+  if not tsu then
+    log.warn("nvim-treesitter not available, treesitter integration disabled")
+    return
+  end
+  Treesitter.ts_utils = tsu
+  local ntp = get_ts_dep("nvim-treesitter.parsers")
+  local install = get_ts_dep("nvim-treesitter.install")
 
   if Treesitter.config.configure_parsers then
     -- luacheck: push ignore

--- a/lua/down/mod/link/init.lua
+++ b/lua/down/mod/link/init.lua
@@ -2,7 +2,7 @@ local config = require 'down.config'
 local mod = require 'down.mod'
 local util = require 'down.util'
 local tsu_ok, tsu = pcall(require, 'nvim-treesitter.ts_utils')
-local log = log
+local log = require("down.log")
 local ts = vim.treesitter
 local tsq = vim.treesitter.query
 

--- a/lua/down/mod/lsp/init.lua
+++ b/lua/down/mod/lsp/init.lua
@@ -1,0 +1,247 @@
+local log = require ("down.log")
+local mod = require ("down.mod")
+
+---@class down.mod.lsp.Lsp: down.Mod
+local Lsp = mod.new ("lsp")
+
+---@class down.mod.lsp.Config
+Lsp.config = {
+  --- Enable auto-download of down.lsp binary
+  auto_download = true,
+  --- GitHub repo for down.lsp releases
+  repo = "clpi/down.lsp",
+  --- Binary name
+  bin = "down-lsp",
+  --- Custom binary path (overrides auto-download)
+  cmd = nil,
+  --- Additional LSP settings to pass
+  settings = {},
+  --- Filetypes to attach LSP
+  filetypes = { "markdown" },
+  --- Root directory markers
+  root_markers = { ".down", ".git", "index.md" },
+}
+
+---@return down.mod.Setup
+Lsp.setup = function ()
+  return {
+    loaded = true,
+    dependencies = { "workspace" },
+  }
+end
+
+--- Get the install directory for the LSP binary
+---@return string
+Lsp.install_dir = function ()
+  local dir = vim.fs.joinpath (vim.fn.stdpath ("data"), "down", "lsp")
+  vim.fn.mkdir (dir, "p")
+  return dir
+end
+
+--- Get the binary path
+---@return string
+Lsp.bin_path = function ()
+  if Lsp.config.cmd then
+    return Lsp.config.cmd
+  end
+  local bin = Lsp.config.bin
+  if vim.fn.has ("win32") == 1 then
+    bin = bin .. ".exe"
+  end
+  return vim.fs.joinpath (Lsp.install_dir (), bin)
+end
+
+--- Check if the binary is installed
+---@return boolean
+Lsp.is_installed = function ()
+  return vim.fn.executable (Lsp.bin_path ()) == 1
+end
+
+--- Detect the platform for download
+---@return string?
+Lsp.platform = function ()
+  local os_name = vim.loop.os_uname ().sysname
+  local arch = vim.loop.os_uname ().machine
+  if os_name == "Linux" then
+    if arch == "x86_64" then
+      return "linux-amd64"
+    elseif arch == "aarch64" then
+      return "linux-arm64"
+    end
+  elseif os_name == "Darwin" then
+    if arch == "arm64" then
+      return "darwin-arm64"
+    else
+      return "darwin-amd64"
+    end
+  elseif os_name == "Windows_NT" then
+    return "windows-amd64"
+  end
+  return nil
+end
+
+--- Download and install the LSP binary
+---@param cb? fun(success: boolean)
+Lsp.download = function (cb)
+  local platform = Lsp.platform ()
+  if not platform then
+    log.warn ("down.lsp: unsupported platform for auto-download")
+    if cb then
+      cb (false)
+    end
+    return
+  end
+
+  local bin_name = Lsp.config.bin
+  if vim.fn.has ("win32") == 1 then
+    bin_name = bin_name .. ".exe"
+  end
+
+  vim.notify ("[down.nvim] Downloading down.lsp...", vim.log.levels.INFO)
+
+  local install_dir = Lsp.install_dir ()
+  local url = string.format (
+    "https://github.com/%s/releases/latest/download/%s-%s",
+    Lsp.config.repo,
+    Lsp.config.bin,
+    platform
+  )
+  local dest = vim.fs.joinpath (install_dir, bin_name)
+
+  vim.fn.jobstart ({ "curl", "-sL", "-o", dest, url }, {
+    on_exit = function (_, code)
+      if code == 0 then
+        vim.fn.setfperm (dest, "rwxr-xr-x")
+        vim.schedule (function ()
+          vim.notify (
+            "[down.nvim] down.lsp installed successfully",
+            vim.log.levels.INFO
+          )
+          if cb then
+            cb (true)
+          end
+        end)
+      else
+        vim.schedule (function ()
+          vim.notify (
+            "[down.nvim] Failed to download down.lsp",
+            vim.log.levels.WARN
+          )
+          if cb then
+            cb (false)
+          end
+        end)
+      end
+    end,
+  })
+end
+
+--- Get workspace folders from workspace module
+---@return lsp.WorkspaceFolder[]
+Lsp.workspace_folders = function ()
+  local ws = mod.get_mod ("workspace")
+  if ws and ws.as_lsp_workspaces then
+    return ws.as_lsp_workspaces ()
+  end
+  return {
+    {
+      name = "default",
+      uri = vim.uri_from_fname (vim.fn.getcwd ()),
+    },
+  }
+end
+
+--- Start the LSP client
+Lsp.start = function ()
+  if not Lsp.is_installed () then
+    if Lsp.config.auto_download then
+      Lsp.download (function (success)
+        if success then
+          vim.schedule (function ()
+            Lsp.attach ()
+          end)
+        end
+      end)
+    else
+      log.info (
+        "down.lsp not installed. Set config.lsp.auto_download = true or provide config.lsp.cmd"
+      )
+    end
+    return
+  end
+  Lsp.attach ()
+end
+
+--- Attach LSP to current buffer
+Lsp.attach = function ()
+  local cmd_path = Lsp.bin_path ()
+  if vim.fn.executable (cmd_path) ~= 1 then
+    return
+  end
+
+  local client_id = vim.lsp.start ({
+    name = "down-lsp",
+    cmd = { cmd_path, "serve" },
+    filetypes = Lsp.config.filetypes,
+    root_dir = vim.fs.root (0, Lsp.config.root_markers) or vim.fn.getcwd (),
+    workspace_folders = Lsp.workspace_folders (),
+    settings = Lsp.config.settings,
+    capabilities = vim.lsp.protocol.make_client_capabilities (),
+  })
+
+  if client_id then
+    vim.lsp.buf_attach_client (0, client_id)
+  end
+end
+
+Lsp.commands = {
+  lsp = {
+    name = "lsp",
+    args = 0,
+    max_args = 1,
+    callback = function (e)
+      Lsp.start ()
+    end,
+    commands = {
+      start = {
+        name = "lsp.start",
+        args = 0,
+        callback = function ()
+          Lsp.start ()
+        end,
+      },
+      install = {
+        name = "lsp.install",
+        args = 0,
+        callback = function ()
+          Lsp.download ()
+        end,
+      },
+      status = {
+        name = "lsp.status",
+        args = 0,
+        callback = function ()
+          if Lsp.is_installed () then
+            vim.notify (
+              "[down.nvim] down.lsp is installed at: " .. Lsp.bin_path ()
+            )
+          else
+            vim.notify ("[down.nvim] down.lsp is not installed")
+          end
+        end,
+      },
+    },
+  },
+}
+
+Lsp.load = function ()
+  vim.api.nvim_create_autocmd ("FileType", {
+    pattern = Lsp.config.filetypes,
+    callback = function ()
+      Lsp.start ()
+    end,
+    desc = "Start down.lsp for markdown files",
+  })
+end
+
+return Lsp

--- a/lua/down/mod/mcp/init.lua
+++ b/lua/down/mod/mcp/init.lua
@@ -1,0 +1,252 @@
+local log = require ("down.log")
+local mod = require ("down.mod")
+
+---@class down.mod.mcp.Mcp: down.Mod
+local Mcp = mod.new ("mcp")
+
+---@class down.mod.mcp.Config
+Mcp.config = {
+  --- Enable auto-download of down.mcp binary
+  auto_download = true,
+  --- GitHub repo for down.mcp releases
+  repo = "clpi/down.mcp",
+  --- Binary name
+  bin = "down-mcp",
+  --- Custom binary path (overrides auto-download)
+  cmd = nil,
+  --- Transport mode: "stdio" or "sse"
+  transport = "stdio",
+  --- Port for SSE transport
+  port = 3001,
+  --- Enable knowledge graph operations via MCP
+  knowledge_graph = true,
+}
+
+---@return down.mod.Setup
+Mcp.setup = function ()
+  return {
+    loaded = true,
+    dependencies = { "workspace", "data" },
+  }
+end
+
+--- Get the install directory for the MCP binary
+---@return string
+Mcp.install_dir = function ()
+  local dir = vim.fs.joinpath (vim.fn.stdpath ("data"), "down", "mcp")
+  vim.fn.mkdir (dir, "p")
+  return dir
+end
+
+--- Get the binary path
+---@return string
+Mcp.bin_path = function ()
+  if Mcp.config.cmd then
+    return Mcp.config.cmd
+  end
+  local bin = Mcp.config.bin
+  if vim.fn.has ("win32") == 1 then
+    bin = bin .. ".exe"
+  end
+  return vim.fs.joinpath (Mcp.install_dir (), bin)
+end
+
+--- Check if the binary is installed
+---@return boolean
+Mcp.is_installed = function ()
+  return vim.fn.executable (Mcp.bin_path ()) == 1
+end
+
+--- Detect the platform for download
+---@return string?
+Mcp.platform = function ()
+  local os_name = vim.loop.os_uname ().sysname
+  local arch = vim.loop.os_uname ().machine
+  if os_name == "Linux" then
+    if arch == "x86_64" then
+      return "linux-amd64"
+    elseif arch == "aarch64" then
+      return "linux-arm64"
+    end
+  elseif os_name == "Darwin" then
+    if arch == "arm64" then
+      return "darwin-arm64"
+    else
+      return "darwin-amd64"
+    end
+  elseif os_name == "Windows_NT" then
+    return "windows-amd64"
+  end
+  return nil
+end
+
+--- Download and install the MCP server binary
+---@param cb? fun(success: boolean)
+Mcp.download = function (cb)
+  local platform = Mcp.platform ()
+  if not platform then
+    log.warn ("down.mcp: unsupported platform for auto-download")
+    if cb then
+      cb (false)
+    end
+    return
+  end
+
+  local bin_name = Mcp.config.bin
+  if vim.fn.has ("win32") == 1 then
+    bin_name = bin_name .. ".exe"
+  end
+
+  vim.notify ("[down.nvim] Downloading down.mcp...", vim.log.levels.INFO)
+
+  local install_dir = Mcp.install_dir ()
+  local url = string.format (
+    "https://github.com/%s/releases/latest/download/%s-%s",
+    Mcp.config.repo,
+    Mcp.config.bin,
+    platform
+  )
+  local dest = vim.fs.joinpath (install_dir, bin_name)
+
+  vim.fn.jobstart ({ "curl", "-sL", "-o", dest, url }, {
+    on_exit = function (_, code)
+      if code == 0 then
+        vim.fn.setfperm (dest, "rwxr-xr-x")
+        vim.schedule (function ()
+          vim.notify (
+            "[down.nvim] down.mcp installed successfully",
+            vim.log.levels.INFO
+          )
+          if cb then
+            cb (true)
+          end
+        end)
+      else
+        vim.schedule (function ()
+          vim.notify (
+            "[down.nvim] Failed to download down.mcp",
+            vim.log.levels.WARN
+          )
+          if cb then
+            cb (false)
+          end
+        end)
+      end
+    end,
+  })
+end
+
+---@type number?
+Mcp.job_id = nil
+
+--- Start the MCP server process
+Mcp.start = function ()
+  if Mcp.job_id then
+    return
+  end
+  if not Mcp.is_installed () then
+    if Mcp.config.auto_download then
+      Mcp.download (function (success)
+        if success then
+          vim.schedule (function ()
+            Mcp.start ()
+          end)
+        end
+      end)
+    else
+      log.info (
+        "down.mcp not installed. Set config.mcp.auto_download = true or provide config.mcp.cmd"
+      )
+    end
+    return
+  end
+
+  local cmd_path = Mcp.bin_path ()
+  local args = { cmd_path, "serve" }
+  if Mcp.config.transport == "sse" then
+    table.insert (args, "--transport")
+    table.insert (args, "sse")
+    table.insert (args, "--port")
+    table.insert (args, tostring (Mcp.config.port))
+  end
+
+  Mcp.job_id = vim.fn.jobstart (args, {
+    on_exit = function (_, code)
+      Mcp.job_id = nil
+      if code ~= 0 then
+        log.warn ("down.mcp exited with code: " .. code)
+      end
+    end,
+    on_stderr = function (_, data)
+      for _, line in ipairs (data) do
+        if line ~= "" then
+          log.trace ("down.mcp: " .. line)
+        end
+      end
+    end,
+  })
+end
+
+--- Stop the MCP server process
+Mcp.stop = function ()
+  if Mcp.job_id then
+    vim.fn.jobstop (Mcp.job_id)
+    Mcp.job_id = nil
+  end
+end
+
+Mcp.commands = {
+  mcp = {
+    name = "mcp",
+    args = 0,
+    max_args = 1,
+    callback = function (e)
+      Mcp.start ()
+    end,
+    commands = {
+      start = {
+        name = "mcp.start",
+        args = 0,
+        callback = function ()
+          Mcp.start ()
+        end,
+      },
+      stop = {
+        name = "mcp.stop",
+        args = 0,
+        callback = function ()
+          Mcp.stop ()
+        end,
+      },
+      install = {
+        name = "mcp.install",
+        args = 0,
+        callback = function ()
+          Mcp.download ()
+        end,
+      },
+      status = {
+        name = "mcp.status",
+        args = 0,
+        callback = function ()
+          if Mcp.is_installed () then
+            local running = Mcp.job_id and "running" or "stopped"
+            vim.notify ("[down.nvim] down.mcp is installed (" .. running .. ")")
+          else
+            vim.notify ("[down.nvim] down.mcp is not installed")
+          end
+        end,
+      },
+    },
+  },
+}
+
+Mcp.load = function ()
+  vim.api.nvim_create_autocmd ("VimLeavePre", {
+    callback = function ()
+      Mcp.stop ()
+    end,
+  })
+end
+
+return Mcp

--- a/lua/down/mod/note/init.lua
+++ b/lua/down/mod/note/init.lua
@@ -1,182 +1,182 @@
-local config = require("down.config")
-local down = require("down")
-local mod = require("down.mod")
-local noteutil = require("down.mod.note.util")
-local util = require("down.util")
-local sep, log = util.sep, log
+local config = require ("down.config")
+local log = require ("down.log")
+local mod = require ("down.mod")
+local noteutil = require ("down.mod.note.util")
+local util = require ("down.util")
+local sep = util.sep
 
 ---@class down.mod.note.Note: down.Mod
-local Note = mod.new("note")
+local Note = mod.new ("note")
 
 Note.maps = {
-  { "n", ",dn", "<CMD>Down note today<CR>",       "Down today note" },
-  { "n", ",dN", "<CMD>Down note index<CR>",       "Down today note" },
+  { "n", ",dn", "<CMD>Down note today<CR>", "Down today note" },
+  { "n", ",dN", "<CMD>Down note index<CR>", "Down today note" },
   { "n", ",dm", "<CMD>Down note month index<CR>", "Down today note" },
-  { "n", ",dy", "<CMD>Down note year index<CR>",  "Down today note" },
-  { "n", ",dt", "<CMD>Down note tempalte<CR>",    "Down today note" },
-  { "n", ",dy", "<CMD>Down note yesterday<CR>",   "Down yesterday note" },
-  { "n", ",dt", "<CMD>Down note tomorrow<CR>",    "Down tomorrow note" },
-  { "n", ",dc", "<CMD>Down note capture<CR>",     "Down capture note" },
+  { "n", ",dy", "<CMD>Down note year index<CR>", "Down today note" },
+  { "n", ",dt", "<CMD>Down note tempalte<CR>", "Down today note" },
+  { "n", ",dy", "<CMD>Down note yesterday<CR>", "Down yesterday note" },
+  { "n", ",dt", "<CMD>Down note tomorrow<CR>", "Down tomorrow note" },
+  { "n", ",dc", "<CMD>Down note capture<CR>", "Down capture note" },
 }
 
 ---@class down.mod.note.Data
-Note.week_index = function()
-  local wk = os.date("%V")
+Note.week_index = function ()
+  local wk = os.date ("%V")
 end
-Note.year_index = function()
-  local yr = os.date("%Y")
-  local ws = Note.config.workspace or Note.dep["workspace"].current()
-  local ws_path = Note.dep["workspace"].get(ws)
+Note.year_index = function ()
+  local yr = os.date ("%Y")
+  local ws = Note.config.workspace or Note.dep["workspace"].current ()
+  local ws_path = Note.dep["workspace"].get (ws)
   local ix = Note.config.note_folder .. sep .. yr .. sep .. Note.config.index
   local path = ws_path .. sep .. ix
-  local index_exists = Note.dep["workspace"].exists(path)
+  local index_exists = Note.dep["workspace"].exists (path)
   if not index_exists then
-    Note.dep["workspace"].new_file(ix, ws)
+    Note.dep["workspace"].new_file (ix, ws)
   end
-  Note.dep["workspace"].open_file(ws, ix)
+  Note.dep["workspace"].open_file (ws, ix)
 end
-Note.month_index = function()
-  local yr = os.date("%Y")
-  local mo = os.date("%m")
-  local ws = Note.config.workspace or Note.dep["workspace"].current()
-  local ws_path = Note.dep["workspace"].get(ws)
+Note.month_index = function ()
+  local yr = os.date ("%Y")
+  local mo = os.date ("%m")
+  local ws = Note.config.workspace or Note.dep["workspace"].current ()
+  local ws_path = Note.dep["workspace"].get (ws)
   local ix = Note.config.note_folder
-      .. sep
-      .. yr
-      .. sep
-      .. mo
-      .. sep
-      .. Note.config.index
+    .. sep
+    .. yr
+    .. sep
+    .. mo
+    .. sep
+    .. Note.config.index
   local path = ws_path .. sep .. ix
-  local index_exists = Note.dep["workspace"].exists(path)
+  local index_exists = Note.dep["workspace"].exists (path)
   if index_exists then
-    Note.dep["workspace"].open_file(ws, ix)
+    Note.dep["workspace"].open_file (ws, ix)
   else
-    Note.dep["workspace"].new_file(ix, ws)
-    Note.dep["workspace"].open_file(ws, ix)
+    Note.dep["workspace"].new_file (ix, ws)
+    Note.dep["workspace"].open_file (ws, ix)
   end
 end
 ---TODO: select onth from vim.ui.select
-Note.select_month = function() end
-Note.note_index = function()
-  local ws = Note.config.workspace or Note.dep["workspace"].current()
-  local ws_path = Note.dep["workspace"].get(ws)
+Note.select_month = function () end
+Note.note_index = function ()
+  local ws = Note.config.workspace or Note.dep["workspace"].current ()
+  local ws_path = Note.dep["workspace"].get (ws)
   local ix = Note.config.note_folder .. sep .. Note.config.index
   local path = ws_path .. sep .. ix
-  local index_exists = Note.dep["workspace"].exists(path)
+  local index_exists = Note.dep["workspace"].exists (path)
   if not index_exists then
-    Note.dep["workspace"].new_file(ix, ws)
+    Note.dep["workspace"].new_file (ix, ws)
   end
-  Note.dep["workspace"].open_file(ws, ix)
+  Note.dep["workspace"].open_file (ws, ix)
 end
 --- Opens a note entry at the given time
 ---@param time? number #The time to open the note entry at as returned by `os.time()`
 ---@param custom_date? string #A YYYY-mm-dd string that specifies a date to open the note at instead
-Note.open_year = function(time, custom_date)
-  local workspace = Note.config.workspace or Note.dep["workspace"].current()
-  local workspace_path = Note.dep["workspace"].get(workspace)
+Note.open_year = function (time, custom_date)
+  local workspace = Note.config.workspace or Note.dep["workspace"].current ()
+  local workspace_path = Note.dep["workspace"].get (workspace)
   local folder_name = Note.config.note_folder
   local tmpl = Note.config.template.year
   if custom_date then
-    local year, _month, _day = custom_date:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
+    local year, _month, _day = custom_date:match ("^(%d%d%d%d)-(%d%d)-(%d%d)$")
     if not year then
-      log.error("Wrong date format: use YYYY-mm-dd")
+      log.error ("Wrong date format: use YYYY-mm-dd")
       return
     end
-    time = os.time({
+    time = os.time ({
       year = year,
       month = 1,
       day = 1,
     })
   end
 
-  local path = os.date(
-    type(Note.config.strategy) == "function"
-    and Note.config.strategy(os.date("*t", time))
-    or Note.config.strategy,
+  local path = os.date (
+    type (Note.config.strategy) == "function"
+        and Note.config.strategy (os.date ("*t", time))
+      or Note.config.strategy,
     time
   )
 
-  local note_file_exists = Note.dep["workspace"].exists(
+  local note_file_exists = Note.dep["workspace"].exists (
     workspace_path .. sep .. folder_name .. sep .. path
   )
 
-  Note.dep["workspace"].new_file(folder_name .. sep .. path, workspace)
+  Note.dep["workspace"].new_file (folder_name .. sep .. path, workspace)
 
   if
-      not note_file_exists
-      and Note.config.template.enable
-      and Note.dep["workspace"].exists(
-        workspace_path .. sep .. folder_name .. sep .. tmpl
-      )
+    not note_file_exists
+    and Note.config.template.enable
+    and Note.dep["workspace"].exists (
+      workspace_path .. sep .. folder_name .. sep .. tmpl
+    )
   then
-    vim.cmd(
+    vim.cmd (
       "$read "
-      .. workspace_path
-      .. sep
-      .. folder_name
-      .. sep
-      .. tmpl
-      .. "| silent! w"
+        .. workspace_path
+        .. sep
+        .. folder_name
+        .. sep
+        .. tmpl
+        .. "| silent! w"
     )
   end
 end
 ---@param time? number #The time to open the note entry at as returned by `os.time()`
 ---@param custom_date? string #A YYYY-mm-dd string that specifies a date to open the note at instead
-Note.open_month = function(time, custom_date)
-  local workspace = Note.config.workspace or Note.dep["workspace"].current()
-  local workspace_path = Note.dep["workspace"].get(workspace)
+Note.open_month = function (time, custom_date)
+  local workspace = Note.config.workspace or Note.dep["workspace"].current ()
+  local workspace_path = Note.dep["workspace"].get (workspace)
   local folder_name = Note.config.note_folder
   local tmpl = Note.config.template.month
 
   if custom_date then
-    local year, month, day = custom_date:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
+    local year, month, day = custom_date:match ("^(%d%d%d%d)-(%d%d)-(%d%d)$")
 
     if not year or not month or not day then
-      log.error("Wrong date format: use YYYY-mm-dd")
+      log.error ("Wrong date format: use YYYY-mm-dd")
       return
     end
 
-    time = os.time({
+    time = os.time ({
       year = year,
       month = month,
       day = day,
     })
   end
 
-  local path = os.date(
-    type(Note.config.strategy) == "function"
-    and Note.config.strategy(os.date("*t", time))
-    or Note.config.strategy,
+  local path = os.date (
+    type (Note.config.strategy) == "function"
+        and Note.config.strategy (os.date ("*t", time))
+      or Note.config.strategy,
     time
   )
 
-  local note_file_exists = Note.dep["workspace"].exists(
+  local note_file_exists = Note.dep["workspace"].exists (
     workspace_path .. sep .. folder_name .. sep .. path
   )
 
-  Note.dep["workspace"].new_file(folder_name .. sep .. path, workspace)
+  Note.dep["workspace"].new_file (folder_name .. sep .. path, workspace)
 
   if
-      not note_file_exists
-      and Note.config.template.enable
-      and Note.dep["workspace"].exists(
-        workspace_path .. sep .. folder_name .. sep .. tmpl
-      )
+    not note_file_exists
+    and Note.config.template.enable
+    and Note.dep["workspace"].exists (
+      workspace_path .. sep .. folder_name .. sep .. tmpl
+    )
   then
-    vim.cmd(
+    vim.cmd (
       "$read "
-      .. workspace_path
-      .. sep
-      .. folder_name
-      .. sep
-      .. tmpl
-      .. "| silent! w"
+        .. workspace_path
+        .. sep
+        .. folder_name
+        .. sep
+        .. tmpl
+        .. "| silent! w"
     )
   end
 end
-Note.capture = function()
-  local b, w = Note.dep["ui.win"].win("today", "note", "Down note today")
+Note.capture = function ()
+  local b, w = Note.dep["ui.win"].win ("today", "note", "Down note today")
   -- vim.cmd
 
   -- Noteod.get_mod("ui.win").cmd(w, function()
@@ -187,145 +187,145 @@ end
 --- Opens a note entry at the given time
 ---@param time? number #The time to open the note entry at as returned by `os.time()`
 ---@param custom_date? string #A YYYY-mm-dd string that specifies a date to open the note at instead
-Note.open_note = function(time, custom_date)
-  local workspace = Note.config.workspace or Note.dep["workspace"].current()
-  local workspace_path = Note.dep["workspace"].get(workspace)
+Note.open_note = function (time, custom_date)
+  local workspace = Note.config.workspace or Note.dep["workspace"].current ()
+  local workspace_path = Note.dep["workspace"].get (workspace)
   local folder_name = Note.config.note_folder
   local tmpl = Note.config.template.day
 
   if custom_date then
-    local year, month, day = custom_date:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
+    local year, month, day = custom_date:match ("^(%d%d%d%d)-(%d%d)-(%d%d)$")
 
     if not year or not month or not day then
-      log.error("Wrong date format: use YYYY-mm-dd")
+      log.error ("Wrong date format: use YYYY-mm-dd")
       return
     end
 
-    time = os.time({
+    time = os.time ({
       year = year,
       month = month,
       day = day,
     })
   end
 
-  local path = os.date(
-    type(Note.config.strategy) == "function"
-    and Note.config.strategy(os.date("*t", time))
-    or Note.config.strategy,
+  local path = os.date (
+    type (Note.config.strategy) == "function"
+        and Note.config.strategy (os.date ("*t", time))
+      or Note.config.strategy,
     time
   )
 
-  local note_file_exists = Note.dep["workspace"].exists(
+  local note_file_exists = Note.dep["workspace"].exists (
     workspace_path .. sep .. folder_name .. sep .. path
   )
 
-  Note.dep["workspace"].new_file(folder_name .. sep .. path, workspace)
+  Note.dep["workspace"].new_file (folder_name .. sep .. path, workspace)
 
   if
-      not note_file_exists
-      and Note.config.template.enable
-      and Note.dep["workspace"].exists(
-        workspace_path .. sep .. folder_name .. sep .. tmpl
-      )
+    not note_file_exists
+    and Note.config.template.enable
+    and Note.dep["workspace"].exists (
+      workspace_path .. sep .. folder_name .. sep .. tmpl
+    )
   then
-    vim.cmd(
+    vim.cmd (
       "$read "
-      .. workspace_path
-      .. sep
-      .. folder_name
-      .. sep
-      .. tmpl
-      .. "| silent! w"
+        .. workspace_path
+        .. sep
+        .. folder_name
+        .. sep
+        .. tmpl
+        .. "| silent! w"
     )
   end
 end
 
 --- Opens a note entry for tomorrow's date
-Note.note_tomorrow = function()
-  Note.open_note(os.time() + 24 * 60 * 60)
+Note.note_tomorrow = function ()
+  Note.open_note (os.time () + 24 * 60 * 60)
 end
 
 --- Opens a note entry for yesterday's date
-Note.note_yesterday = function()
-  Note.open_note(os.time() - 24 * 60 * 60)
+Note.note_yesterday = function ()
+  Note.open_note (os.time () - 24 * 60 * 60)
 end
 
-Note.year_prev = function()
-  Note.open_note(os.time() - 24 * 60 * 60 * 365)
+Note.year_prev = function ()
+  Note.open_note (os.time () - 24 * 60 * 60 * 365)
 end
-Note.year_next = function()
-  Note.open_note(os.time() + 24 * 60 * 60 * 365)
+Note.year_next = function ()
+  Note.open_note (os.time () + 24 * 60 * 60 * 365)
 end
-Note.month_prev = function()
-  Note.open_note(os.time() - 24 * 60 * 60 * 30)
-end
-
-Note.month_next = function()
-  Note.open_note(os.time() + 24 * 60 * 60 * 30)
+Note.month_prev = function ()
+  Note.open_note (os.time () - 24 * 60 * 60 * 30)
 end
 
-Note.week_prev = function()
-  Note.open_note(os.time() - 24 * 60 * 60 * 7)
+Note.month_next = function ()
+  Note.open_note (os.time () + 24 * 60 * 60 * 30)
 end
 
-Note.week_next = function()
-  Note.open_note(os.time() + 24 * 60 * 60 * 7)
+Note.week_prev = function ()
+  Note.open_note (os.time () - 24 * 60 * 60 * 7)
+end
+
+Note.week_next = function ()
+  Note.open_note (os.time () + 24 * 60 * 60 * 7)
 end
 
 --- Opens a note entry for today's date
-Note.note_today = function()
-  Note.open_note()
+Note.note_today = function ()
+  Note.open_note ()
 end
 
-Note.create_month_template = function()
+Note.create_month_template = function ()
   local workspace = Note.config.workspace
   local folder_name = Note.config.note_folder
   local tmpl = Note.config.template.month
-  Note.dep["workspace"].new_file(
+  Note.dep["workspace"].new_file (
     folder_name .. sep .. tmpl,
-    workspace or Note.dep["workspace"].current()
+    workspace or Note.dep["workspace"].current ()
   )
 end
 --- Creates a template file
-Note.create_year_template = function()
+Note.create_year_template = function ()
   local workspace = Note.config.workspace
   local folder_name = Note.config.note_folder
   local tmpl = Note.config.template.year
-  Note.dep["workspace"].new_file(
+  Note.dep["workspace"].new_file (
     folder_name .. sep .. tmpl,
-    workspace or Note.dep["workspace"].current()
+    workspace or Note.dep["workspace"].current ()
   )
 end
-Note.create_day_template = function()
+Note.create_day_template = function ()
   local workspace = Note.config.workspace
   local folder_name = Note.config.note_folder
   local tmpl = Note.config.template.day
 
-  Note.dep["workspace"].new_file(
+  Note.dep["workspace"].new_file (
     folder_name .. sep .. tmpl,
-    workspace or Note.dep["workspace"].current()
+    workspace or Note.dep["workspace"].current ()
   )
 end
 
 --- Opens the toc file
-Note.open_toc = function()
-  local workspace = Note.config.workspace or Note.dep["workspace"].current()
-  local index = mod.mod_config("workspace").index
+Note.open_toc = function ()
+  local workspace = Note.config.workspace or Note.dep["workspace"].current ()
+  local index = mod.mod_config ("workspace").index
   local folder_name = Note.config.note_folder
 
   -- If the toc exists, open it, if not, create it
-  if Note.dep["workspace"].exists(folder_name .. sep .. index) then
-    Note.dep["workspace"].open_file(workspace, folder_name .. sep .. index)
+  if Note.dep["workspace"].exists (folder_name .. sep .. index) then
+    Note.dep["workspace"].open_file (workspace, folder_name .. sep .. index)
   else
-    Note.create_toc()
+    Note.create_toc ()
   end
 end
 
 --- Creates or updates the toc file
-Note.create_toc = function()
-  local workspace = Note.config.workspace or Note.dep["workspace"].current()
-  local index = mod.mod_config("workspace").index
-  local workspace_path = Note.dep["workspace"].get(workspace)
+Note.create_toc = function ()
+  local workspace = Note.config.workspace or Note.dep["workspace"].current ()
+  local index = mod.mod_config ("workspace").index
+  local workspace_path = Note.dep["workspace"].get (workspace)
   local workspace_name_for_link = Note.config.workspace or ""
   local folder_name = Note.config.note_folder
 
@@ -334,14 +334,14 @@ Note.create_toc = function()
 
   -- Get a filesystem handle for the files in the note folder
   -- path is for each subfolder
-  local get_fs_handle = function(path)
+  local get_fs_handle = function (path)
     path = path or ""
     local handle =
-        vim.loop.fs_scandir(workspace_path .. sep .. folder_name .. sep .. path)
+      vim.loop.fs_scandir (workspace_path .. sep .. folder_name .. sep .. path)
 
-    if type(handle) ~= "userdata" then
-      error(
-        util.lazy_string_concat(
+    if type (handle) ~= "userdata" then
+      error (
+        util.lazy_string_concat (
           "Failed to scan directory '",
           workspace,
           path,
@@ -355,19 +355,19 @@ Note.create_toc = function()
   end
 
   -- Gets the title from the metadata of a file, must be called in a vim.schedule
-  local get_title = function(file)
+  local get_title = function (file)
     local buffer =
-        vim.fn.bufadd(workspace_path .. sep .. folder_name .. sep .. file)
-    local meta = Note.dep["workspace"].get_document_metadata(buffer)
+      vim.fn.bufadd (workspace_path .. sep .. folder_name .. sep .. file)
+    local meta = Note.dep["workspace"].get_document_metadata (buffer)
     return meta.title
   end
 
-  vim.loop.fs_scandir(
+  vim.loop.fs_scandir (
     workspace_path .. sep .. folder_name .. sep,
-    function(err, handle)
-      assert(
+    function (err, handle)
+      assert (
         not err,
-        util.lazy_string_concat(
+        util.lazy_string_concat (
           "Unable to generate TOC for directory '",
           folder_name,
           "' - ",
@@ -377,53 +377,53 @@ Note.create_toc = function()
 
       while true do
         -- Name corresponds to either a YYYY-mm-dd.down file, or just the year ("nested" strategy)
-        local name, type = vim.loop.fs_scandir_next(handle) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+        local name, type = vim.loop.fs_scandir_next (handle) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
         if not name then
           break
         end
         if type == "directory" then
-          local years_handle = get_fs_handle(name)
+          local years_handle = get_fs_handle (name)
           while true do
-            local mname, mtype = vim.loop.fs_scandir_next(years_handle)
+            local mname, mtype = vim.loop.fs_scandir_next (years_handle)
             if not mname then
               break
             end
 
             if mtype == "directory" then
-              local months_handle = get_fs_handle(name .. sep .. mname)
+              local months_handle = get_fs_handle (name .. sep .. mname)
               while true do
-                local dname, dtype = vim.loop.fs_scandir_next(months_handle)
+                local dname, dtype = vim.loop.fs_scandir_next (months_handle)
                 if not dname then
                   break
                 end
 
                 -- If it's a .down file, also ensure it is a day entry
-                if dtype == "file" and (dname):match("%d%d%.md") then
+                if dtype == "file" and (dname):match ("%d%d%.md") then
                   -- Split the file name
-                  local file = vim.split(dname, ".", { plain = true })
+                  local file = vim.split (dname, ".", { plain = true })
 
-                  vim.schedule(function()
+                  vim.schedule (function ()
                     -- Get the title from the metadata, else, it just base to the name of the file
-                    local title = get_title(
+                    local title = get_title (
                       name .. sep .. mname .. sep .. dname
                     ) or file[1]
 
                     -- Insert a new entry
-                    table.insert(toc_entries, {
-                      tonumber(name),
-                      tonumber(mname),
-                      tonumber(file[1]),
+                    table.insert (toc_entries, {
+                      tonumber (name),
+                      tonumber (mname),
+                      tonumber (file[1]),
                       "{:$"
-                      .. workspace_name_for_link
-                      .. sep
-                      .. Note.config.note_folder
-                      .. sep
-                      .. name
-                      .. sep
-                      .. mname
-                      .. sep
-                      .. file[1]
-                      .. ":}",
+                        .. workspace_name_for_link
+                        .. sep
+                        .. Note.config.note_folder
+                        .. sep
+                        .. name
+                        .. sep
+                        .. mname
+                        .. sep
+                        .. file[1]
+                        .. ":}",
                       title,
                     })
                   end)
@@ -437,69 +437,69 @@ Note.create_toc = function()
         -- If it is a .down file, but it's not any user generated file.
         -- The match is here to avoid handling files made by the user, like a template file, or
         -- the toc file
-        if type == "file" and string.match(name, "%d+-%d+-%d+%.md") then
+        if type == "file" and string.match (name, "%d+-%d+-%d+%.md") then
           -- Split yyyy-mm-dd to a table
-          local file = vim.split(name, ".", { plain = true })
-          local parts = vim.split(file[1], "-")
+          local file = vim.split (name, ".", { plain = true })
+          local parts = vim.split (file[1], "-")
 
           -- Convert the parts into numbers
-          for k, v in pairs(parts) do
-            parts[k] = tonumber(v) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+          for k, v in pairs (parts) do
+            parts[k] = tonumber (v) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
           end
 
-          vim.schedule(function()
+          vim.schedule (function ()
             -- Get the title from the metadata, else, it just base to the name of the file
-            local title = get_title(name) or parts[3]
+            local title = get_title (name) or parts[3]
 
             -- And insert a new entry that corresponds to the file
-            table.insert(toc_entries, {
+            table.insert (toc_entries, {
               parts[1],
               parts[2],
               parts[3],
               "{:$"
-              .. workspace_name_for_link
-              .. sep
-              .. Note.config.note_folder
-              .. sep
-              .. file[1]
-              .. ":}",
+                .. workspace_name_for_link
+                .. sep
+                .. Note.config.note_folder
+                .. sep
+                .. file[1]
+                .. ":}",
               title,
             })
           end)
         end
       end
 
-      vim.schedule(function()
+      vim.schedule (function ()
         local format = Note.config.toc_format
-            or function(entries)
-              local months_text = Note.months
-              local output = {}
-              local current_year, current_month
-              for _, entry in ipairs(entries) do
-                if not current_year or current_year < entry[1] then
-                  current_year = entry[1]
-                  current_month = nil
-                  output:insert("* " .. current_year)
-                end
-                if not current_month or current_month < entry[2] then
-                  current_month = entry[2]
-                  output:insert("** " .. months_text[current_month])
-                end
-
-                -- Prints the file link
-                output:insert("   " .. entry[4] .. ("[%s]"):format(entry[5]))
+          or function (entries)
+            local months_text = Note.months
+            local output = {}
+            local current_year, current_month
+            for _, entry in ipairs (entries) do
+              if not current_year or current_year < entry[1] then
+                current_year = entry[1]
+                current_month = nil
+                output:insert ("* " .. current_year)
+              end
+              if not current_month or current_month < entry[2] then
+                current_month = entry[2]
+                output:insert ("** " .. months_text[current_month])
               end
 
-              return output
+              -- Prints the file link
+              output:insert ("   " .. entry[4] .. ("[%s]"):format (entry[5]))
             end
 
-        Note.dep["workspace"].new_file(
+            return output
+          end
+
+        Note.dep["workspace"].new_file (
           folder_name .. sep .. index,
-          workspace or Note.dep["workspace"].current()
+          workspace or Note.dep["workspace"].current ()
         )
 
         -- The current buffer now must be the toc file, so we set our toc entries there
-        vim.api.nvim_buf_set_lines(0, 0, -1, false, format(toc_entries))
+        vim.api.nvim_buf_set_lines (0, 0, -1, false, format (toc_entries))
         -- vim.cmd("w")
       end)
     end
@@ -549,27 +549,27 @@ Note.config.strategies = {
   nested = "%Y" .. sep .. "%m" .. sep .. "%d.md",
 }
 
-Note.open_month_calendar = function(event)
+Note.open_month_calendar = function (event)
   if not event.body[1] then
     local cal = Note.dep["ui.calendar"]
     if not cal then
-      log.error("[ERROR]: `ui.calendar` is not loaded!")
+      log.error ("[ERROR]: `ui.calendar` is not loaded!")
       return
     end
-    cal.select_date({
-      callback = vim.schedule_wrap(function(osdate)
-        Note.open_note(
+    cal.select_date ({
+      callback = vim.schedule_wrap (function (osdate)
+        Note.open_note (
           nil,
-          ("%04d"):format(osdate.year)
-          .. "-"
-          .. ("%02d"):format(osdate.month)
-          .. "-"
-          .. ("%02d"):format(osdate.day)
+          ("%04d"):format (osdate.year)
+            .. "-"
+            .. ("%02d"):format (osdate.month)
+            .. "-"
+            .. ("%02d"):format (osdate.day)
         )
       end),
     })
   else
-    Note.open_note(nil, event.body[1])
+    Note.open_note (nil, event.body[1])
   end
 end
 
@@ -582,8 +582,8 @@ Note.commands = {
   }, -- format :yyyy-mm-dd
   note = {
     name = "note",
-    callback = function(e)
-      log.trace("note")
+    callback = function (e)
+      log.trace ("note")
     end,
     min_args = 1,
     max_args = 2,
@@ -737,14 +737,14 @@ Note.commands = {
   },
 }
 
-Note.load = function()
+Note.load = function ()
   if Note.config.strategies[Note.config.strategy] then
     Note.config.strategy = Note.config.strategies[Note.config.strategy]
   end
 end
 
 ---@return down.mod.Setup
-Note.setup = function()
+Note.setup = function ()
   return {
     loaded = true,
     dependencies = {

--- a/lua/down/mod/ui/calendar/month/init.lua
+++ b/lua/down/mod/ui/calendar/month/init.lua
@@ -1,7 +1,6 @@
-local down = require("down")
-local util = down.util
-local log = log
-local mod = down.mod
+local util = require("down.util")
+local log = require("down.log")
+local mod = require("down.mod")
 local monthutil = require("down.mod.ui.calendar.month.util")
 
 local Month = mod.new("ui.calendar.month")

--- a/lua/down/mod/ui/hl/init.lua
+++ b/lua/down/mod/ui/hl/init.lua
@@ -1,6 +1,6 @@
-local down = require("down")
-local util = down.util
-local log, mod = down.log, down.mod
+local util = require("down.util")
+local log = require("down.log")
+local mod = require("down.mod")
 
 --- @class down.mod.ui.hl.Hl: down.Mod
 local Hl = mod.new("ui.hl")

--- a/lua/down/mod/ui/icon/init.lua
+++ b/lua/down/mod/ui/icon/init.lua
@@ -1,5 +1,6 @@
-local down = require("down")
-local log, mod, utils = down.log, down.mod, down.utils
+local log = require("down.log")
+local mod = require("down.mod")
+local utils = require("down.util")
 
 --- @class down.mod.ui.icon.Icon: down.Mod
 local Icon = mod.new("ui.icon", {

--- a/lua/down/mod/util.lua
+++ b/lua/down/mod/util.lua
@@ -32,33 +32,35 @@ U.ids = {
   "ui.calendar.month",
   "cmd",
   "link",
+  "lsp",
+  "mcp",
   "integration.telescope",
   "data.history",
+  "data.knowledge",
   "integration",
 }
 
 ---@return boolean
-U.check_id = function(mod_id)
-  return vim.tbl_contains(U.ids, mod_id)
-    and not (mod_id == "workspace" or mod_id == "workspaces")
+U.check_id = function (mod_id)
+  return vim.tbl_contains (U.ids, mod_id) and mod_id ~= "workspaces"
 end
 
 ---@return boolean
-U.check_default_id = function(mod_id)
-  return vim.tbl_contains(vim.tbl_keys(U.defaults), mod_id)
+U.check_default_id = function (mod_id)
+  return vim.tbl_contains (vim.tbl_keys (U.defaults), mod_id)
 end
 
 ---@return { [down.Mod.Id]?: down.Mod.Config }
-U.merge_default = function(def)
-  return vim.tbl_extend("force", U.defaults, def)
+U.merge_default = function (def)
+  return vim.tbl_extend ("force", U.defaults, def)
 end
 
 ---@return boolean
-U.check_not_default = function(def, defv)
-  return U.check_id(def)
-    and not U.check_default_id(def)
+U.check_not_default = function (def, defv)
+  return U.check_id (def)
+    and not U.check_default_id (def)
     and defv
-    and type(defv) == "table"
+    and type (defv) == "table"
 end
 
 return U

--- a/lua/down/mod/workspace/init.lua
+++ b/lua/down/mod/workspace/init.lua
@@ -1,8 +1,8 @@
-local event = require("down.event")
-local log = require("down.log")
-local mod = require("down.mod")
-local util = require("down.mod.workspace.util")
-local utils = require("down.util")
+local event = require ("down.event")
+local log = require ("down.log")
+local mod = require ("down.mod")
+local util = require ("down.mod.workspace.util")
+local utils = require ("down.util")
 
 local fn, fs, it, uv, dbg =
   vim.fn, vim.fs, vim.iter, (vim.uv or vim.loop), vim.print
@@ -11,19 +11,19 @@ local fn, fs, it, uv, dbg =
 ---@class down.Workspaces: { [string]?: string }
 
 ---@class down.mod.workspace.Workspace: down.Workspaceod
-local Workspace = mod.new("workspace")
+local Workspace = mod.new ("workspace")
 
 ---@return string
-Workspace.path = function(name)
-  return fs.normalize(fn.resolve(fn.expand(Workspace.data.workspaces[name])))
+Workspace.path = function (name)
+  return fs.normalize (fn.resolve (fn.expand (Workspace.data.workspaces[name])))
 end
 
-Workspace.home = function()
-  return Workspace.path(uv.os_homedir())
+Workspace.home = function ()
+  return Workspace.path (uv.os_homedir ())
 end
 
 ---@class down.mod.workspace.Data
-Workspace.data = setmetatable({
+Workspace.data = setmetatable ({
   ---@type down.Workspaces
   workspaces = {},
   ---@type down.Workspace[]
@@ -35,27 +35,28 @@ Workspace.data = setmetatable({
   ---@type string?
   previous = nil,
 }, {
-  __concat = function(self, key)
-    if type(key) == "string" then
-      return tostring(self) .. key
+  __concat = function (self, key)
+    if type (key) == "string" then
+      return tostring (self) .. key
     end
   end,
-  __newindex = function(self, key, val)
-    -- vim.notify("setting " .. key .. " to " .. vim.inspect(val))
-    rawset(self, key, val)
-    Workspace.dep["data"].set("workspace." .. key, self[key])
-    Workspace.dep.data.flush()
+  __newindex = function (self, key, val)
+    rawset (self, key, val)
+    if Workspace.dep and Workspace.dep["data"] then
+      Workspace.dep["data"].set ("workspace." .. key, self[key])
+      Workspace.dep.data.flush ()
+    end
   end,
-  __tostring = function(self)
-    if type(self) == "table" then
-      return vim.inspect(self)
-    elseif type(self) == "string" then
+  __tostring = function (self)
+    if type (self) == "table" then
+      return vim.inspect (self)
+    elseif type (self) == "string" then
       return "workspace." .. self
     end
-    return vim.inspect(self)
+    return vim.inspect (self)
   end,
   __name = "workspace",
-  __index = function(self, key)
+  __index = function (self, key)
     --   local res = rawget(self, key)
     --   if not res == Workspace.dep["data"].get("workspace." .. key) then
     --     Workspace.dep["data"].set("workspace." .. key, res)
@@ -63,27 +64,30 @@ Workspace.data = setmetatable({
     --   end
     --   return res
     -- key = "workspace." .. key
-    return rawget(self, key)
+    return rawget (self, key)
   end,
   ---@param opts { load: boolean, }
-  __call = function(self, opts)
+  __call = function (self, opts)
+    if not Workspace.dep or not Workspace.dep.data then
+      return
+    end
     if opts and opts.load and opts.load == true then
-      for k, v in pairs(self) do
-        if not Workspace.dep.data.get("workspace." .. k) then
-          Workspace.dep.data.set("workspace." .. k, v)
+      for k, v in pairs (self) do
+        if not Workspace.dep.data.get ("workspace." .. k) then
+          Workspace.dep.data.set ("workspace." .. k, v)
         end
-        if not Workspace.dep.data.get("workspace." .. k) == v then
-          rawset(self, k, Workspace.dep.data.get("workspace." .. k))
+        if not Workspace.dep.data.get ("workspace." .. k) == v then
+          rawset (self, k, Workspace.dep.data.get ("workspace." .. k))
         end
       end
     else
-      for k, v in pairs(self) do
-        if not Workspace.dep.data.get(k) == v then
-          Workspace.dep.data.set("workspace." .. k, v)
+      for k, v in pairs (self) do
+        if not Workspace.dep.data.get (k) == v then
+          Workspace.dep.data.set ("workspace." .. k, v)
         end
       end
     end
-    Workspace.dep.data.flush()
+    Workspace.dep.data.flush ()
   end,
 })
 
@@ -93,8 +97,8 @@ Workspace.config = {
   default = "default",
   --- List of workspaces
   workspaces = {
-    default = vim.fn.getcwd(0),
-    cwd = vim.fn.getcwd(0),
+    default = vim.fn.getcwd (0),
+    cwd = vim.fn.getcwd (0),
   },
   --- The filetype of new douments, markdown is supported only for now
   ft = "markdown",
@@ -106,7 +110,7 @@ Workspace.config = {
 }
 
 ---@return down.mod.Setup
-Workspace.setup = function()
+Workspace.setup = function ()
   return {
     loaded = true,
     dependencies = { "ui", "data", "note", "cmd" },
@@ -120,36 +124,36 @@ Workspace.maps = {
 
 --- Returns an iterator for the workspaces
 --- @return Iter
-Workspace.iter = function()
-  return vim.iter(pairs(Workspace.data.workspaces))
+Workspace.iter = function ()
+  return vim.iter (pairs (Workspace.data.workspaces))
 end
 
 --- Returns the workspace folder as lsp
 --- @return lsp.WorkspaceFolder
 --- @param name? string
 --- @param path? string
-Workspace.as_lsp_workspace = function(name, path)
+Workspace.as_lsp_workspace = function (name, path)
   return {
     name = name or Workspace.data.active,
-    uri = vim.uri_from_fname(
-      path or Workspace.path(name or Workspace.data.active)
+    uri = vim.uri_from_fname (
+      path or Workspace.path (name or Workspace.data.active)
     ),
   }
 end
 
 --- Returns the workspace folders as lsp
 --- @return lsp.WorkspaceFolder[]
-Workspace.as_lsp_workspaces = function()
+Workspace.as_lsp_workspaces = function ()
   return vim
-    .iter(Workspace.data.workspaces)
-    :map(Workspace.as_lsp_workspace)
-    :totable()
+    .iter (Workspace.data.workspaces)
+    :map (Workspace.as_lsp_workspace)
+    :totable ()
 end
 
 --- Loads the workspace module
-Workspace.load = function()
-  vim.iter(Workspace.config.workspaces):each(function(k, v)
-    Workspace.config.workspaces[k] = fs.normalize(fn.resolve(fn.expand(v)))
+Workspace.load = function ()
+  vim.iter (Workspace.config.workspaces):each (function (k, v)
+    Workspace.config.workspaces[k] = fs.normalize (fn.resolve (fn.expand (v)))
   end)
   Workspace.data.workspaces = Workspace.config.workspaces
     or Workspace.data.workspaces
@@ -162,78 +166,78 @@ Workspace.load = function()
   Workspace.data.active = Workspace.data.active
     or Workspace.data.default
     or "default"
-  vim.api.nvim_create_autocmd("BufEnter", {
+  vim.api.nvim_create_autocmd ("BufEnter", {
     pattern = "*",
-    callback = function()
-      mod.await("cmd", function(cmd)
-        cmd.add_commands_from_table(Workspace.commands)
+    callback = function ()
+      mod.await ("cmd", function (cmd)
+        cmd.add_commands_from_table (Workspace.commands)
       end)
     end,
   })
-  Workspace.sync()
+  Workspace.sync ()
 end
 
 --- Returns the index file for a workspace
 ---@class down.mod.workspace.Data
-Workspace.index = function(p)
-  return vim.fs.joinpath(
-    p or Workspace.current_path(),
+Workspace.index = function (p)
+  return vim.fs.joinpath (
+    p or Workspace.current_path (),
     Workspace.config.index .. Workspace.config.ext
   )
 end
 
 --- Returns the current workspace name
 --- @return string
-Workspace.current = function()
+Workspace.current = function ()
   return Workspace.data.active
 end
 
 --- Returns the current workspace path
 --- @return string
-Workspace.current_path = function()
-  return Workspace.path(Workspace.data.active)
+Workspace.current_path = function ()
+  return Workspace.path (Workspace.data.active)
 end
 
 --- Returns all files in a workspace
 --- @return string[]
-Workspace.files = function(ws, patt)
-  return vim.fn.globpath(Workspace.get(ws), patt or "**/*", true, true)
+Workspace.files = function (ws, patt)
+  return vim.fn.globpath (Workspace.get (ws), patt or "**/*", true, true)
 end
 
 --- Opens a file in the current workspace or at path
 ---@param path string
-Workspace.edit = function(path)
-  vim.cmd("silent! e " .. path or Workspace.index())
+Workspace.edit = function (path)
+  vim.cmd ("silent! e " .. path or Workspace.index ())
 end
 
 --- If present retrieve a workspace's path by its name, else returns nil
 ---@param name string #The name of the workspace
-Workspace.get = function(name)
+Workspace.get = function (name)
   if not name then
     return Workspace.data.workspaces[Workspace.data.active]
   end
   return Workspace.data.workspaces[name]
 end
 
-Workspace.set = function(name, path)
-  Workspace.data.workspaces[name] = Workspace.path(path)
+Workspace.set = function (name, path)
+  Workspace.data.workspaces[name] = Workspace.path (path)
 end
-Workspace.has = function(n)
+Workspace.has = function (n)
   return Workspace.data.workspaces[n] ~= nil
 end
 --- Sets the workspace to the one specified (if it exists) and broadcasts the wschanged event
 ---@param n string #The name of a valid namespace we want to switch to
 ---@param create? boolean
 ---@return boolean #True if the workspace is set correctly, false otherwise
-Workspace.set_workspace = function(n, create)
-  if not Workspace.has(n) then
-    log.warn(
+Workspace.set_workspace = function (n, create)
+  if not Workspace.has (n) then
+    log.warn (
       "Unable to set workspace to" .. n .. "- that workspace does not exist"
     )
     return false
   end
-  local p = Workspace.path(Workspace.data.workspaces[n])
-  fn.mkdir(p, "p")
+  local p = Workspace.path (Workspace.data.workspaces[n])
+  fn.mkdir (p, "p")
   Workspace.data.previous = Workspace.data.active
   Workspace.data.active = n
   -- local e = mod.new_event(Workspace, 'workspace.events.wschanged', { old = ws, new = workspace })
@@ -245,74 +249,77 @@ end
 ---@return boolean True if the workspace is added successfully, false otherwise
 ---@param wsname string #The unique name of the new workspace
 ---@param wspath string #A full path to the workspace root
-Workspace.add_workspace = function(wsname, wspath)
+Workspace.add_workspace = function (wsname, wspath)
   if Workspace.data.workspaces[wsname] then
     return false
   end
-  wspath = Workspace.path(wspath)
-  Workspace.data.workspaces[wsname] = Workspace.path(wspath)
-  mod.broadcast(
-    mod.new_event(Workspace, "workspace.events.wsadded", { wsname, wspath })
+  wspath = Workspace.path (wspath)
+  Workspace.data.workspaces[wsname] = Workspace.path (wspath)
+  mod.broadcast (
+    mod.new_event (Workspace, "workspace.events.wsadded", { wsname, wspath })
       or {}
   )
-  Workspace.sync()
+  Workspace.sync ()
   return true
 end
 
 --- Updates completions for the :down command
-Workspace.sync = function()
-  Workspace.data.workspaces = Workspace.data.workspaces
-  Workspace.data.workspace_folders = Workspace.as_lsp_workspaces()
-  Workspace.dep.data.data.workspaces = Workspace.data.workspaces
-  -- Workspace.dep.data.set("workspace.workspaces", Workspace.data.workspaces)
-  Workspace.commands.workspace.complete = { Workspace.names() }
-  Workspace.commands.index.complete = { Workspace.names() }
-  Workspace.data.previous = Workspace.data.previous
+Workspace.sync = function ()
+  Workspace.data.workspace_folders = Workspace.as_lsp_workspaces ()
+  if Workspace.dep and Workspace.dep.data then
+    Workspace.dep.data.data.workspaces = Workspace.data.workspaces
+    Workspace.dep.data.flush ()
+  end
+  if Workspace.commands.workspace then
+    Workspace.commands.workspace.complete = { Workspace.names () }
+  end
+  if Workspace.commands.index then
+    Workspace.commands.index.complete = { Workspace.names () }
+  end
   Workspace.data.workspaces = Workspace.config.workspaces or {}
   Workspace.data.active = Workspace.data.active or Workspace.data.default
   Workspace.data.history = Workspace.data.history or {}
-  Workspace.dep.data.flush()
-  mod.await("cmd", function(cmd)
-    cmd.add_commands_from_table(Workspace.commands)
+  mod.await ("cmd", function (cmd)
+    cmd.add_commands_from_table (Workspace.commands)
   end)
 end
 --- @param prompt? string | nil
 --- @param fmt? fun(item: string): string
 --- @param fn? fun(item: number|string, idx: number|string)|nil
-Workspace.select = function(prompt, fmt, fn)
+Workspace.select = function (prompt, fmt, fn)
   local format = fmt
-    or function(item)
-      local current = Workspace.current()
+    or function (item)
+      local current = Workspace.current ()
       if item == current then
         return "• " .. item
       end
       return item
     end
   local func = fn
-    or function(item, idx)
-      local current = Workspace.current()
+    or function (item, idx)
+      local current = Workspace.current ()
       if not item then
         return
       elseif item == current then
-        vim.notify("Already in workspace " .. current)
+        vim.notify ("Already in workspace " .. current)
       else
-        vim.notify("Workspace set to " .. item)
-        Workspace.set_workspace(item)
+        vim.notify ("Workspace set to " .. item)
+        Workspace.set_workspace (item)
       end
-      Workspace.open(item)
+      Workspace.open (item)
     end
-  return vim.ui.select(Workspace.names(), {
+  return vim.ui.select (Workspace.names (), {
     prompt = prompt or "Select workspace",
     format_items = format,
   }, func)
 end
-Workspace.gets = function()
+Workspace.gets = function ()
   return Workspace.data.workspaces
 end
-Workspace.set_selected = function()
-  local workspace = Workspace.select()
-  Workspace.set_workspace(workspace or Workspace.data.default or "default")
-  vim.notify("Changed workspace to " .. workspace)
+Workspace.set_selected = function ()
+  local workspace = Workspace.select ()
+  Workspace.set_workspace (workspace or Workspace.data.default or "default")
+  vim.notify ("Changed workspace to " .. workspace)
 end
 
 ---@class down.mod.workspace.CreateFileOpts
@@ -323,21 +330,21 @@ end
 ---@param path string
 ---@param workspace? string workspace name
 ---@param opts? down.mod.workspace.CreateFileOpts
-Workspace.new_file = function(path, workspace, opts)
+Workspace.new_file = function (path, workspace, opts)
   opts = opts or { open = true, force = false }
   local fullpath
   if workspace ~= nil then
-    fullpath = Workspace.get(workspace)
+    fullpath = Workspace.get (workspace)
   else
-    fullpath = Workspace.current()[2]
+    fullpath = Workspace.current ()[2]
   end
   if fullpath == nil then
-    return log.error("Error in fetching workspace path")
+    return log.error ("Error in fetching workspace path")
   end
-  local destination = fs.joinpath(fullpath, path)
-  local parent = fs.dirname(destination)
-  if not fn.isdirectory(parent) then
-    fn.mkdir(parent, "p")
+  local destination = fs.joinpath (fullpath, path)
+  local parent = fs.dirname (destination)
+  if not fn.isdirectory (parent) then
+    fn.mkdir (parent, "p")
   end
   -- mod.broadcast(
   --   mod.new_event(
@@ -347,112 +354,112 @@ Workspace.new_file = function(path, workspace, opts)
   --   ) or {}
   -- )
   if opts.open then
-    vim.cmd("e " .. destination .. "| silent! w")
+    vim.cmd ("e " .. destination .. "| silent! w")
   end
 end
 
 --- Takes in a workspace name and a path for a file and opens it
 ---@param wsname string #The name of the workspace to use
 ---@param path string #A path to open the file (e.g directory/filename.down)
-Workspace.open_file = function(wsname, path)
-  local workspace = Workspace.get(wsname)
+Workspace.open_file = function (wsname, path)
+  local workspace = Workspace.get (wsname)
   if workspace == nil then
     return
   end
-  vim.cmd("e " .. fs.joinpath(workspace, path) .. " | silent! w")
+  vim.cmd ("e " .. fs.joinpath (workspace, path) .. " | silent! w")
 end
-Workspace.set_last_workspace = function()
+Workspace.set_last_workspace = function ()
   local prev = Workspace.data.previous or Workspace.data.default or ""
-  local wspath = Workspace.get(Workspace.data.previous)
+  local wspath = Workspace.get (Workspace.data.previous)
   if not wspath then
-    log.trace(
+    log.trace (
       "Unable to switch to workspace '"
         .. prev
         .. "'. The workspace does not exist."
     )
     return
   end
-  if Workspace.set_workspace(prev) then
-    vim.cmd("e " .. Workspace.index(wspath))
-    vim.notify("Last workspace -> " .. wspath)
+  if Workspace.set_workspace (prev) then
+    vim.cmd ("e " .. Workspace.index (wspath))
+    vim.notify ("Last workspace -> " .. wspath)
   end
 end
 --- Checks for file existence by supplying a full path in `filepath`
 ---@param filepath string
-Workspace.exists = function(filepath)
-  return fn.filereadable(filepath)
+Workspace.exists = function (filepath)
+  return fn.filereadable (filepath)
 end
 --- Get the bufnr for a `filepath` (full path)
 ---@param filepath string
-Workspace.bufnr = function(filepath)
-  if Workspace.exists(filepath) then
-    local uri = vim.uri_from_fname(tostring(filepath))
-    return vim.uri_to_bufnr(uri)
+Workspace.bufnr = function (filepath)
+  if Workspace.exists (filepath) then
+    local uri = vim.uri_from_fname (tostring (filepath))
+    return vim.uri_to_bufnr (uri)
   end
 end
 --- Returns a list of all files relative path from a `wsname`
 ---@param wsname string
 ---@return string?
-Workspace.notes = function(wsname, year, month)
-  local workspace = Workspace.get(wsname)
+Workspace.notes = function (wsname, year, month)
+  local workspace = Workspace.get (wsname)
   if not workspace then
     return
   end
-  local nd = mod.get_mod("note").config.note_folder
-  local wn = vim.fs.joinpath(workspace, nd)
-  return vim.fn.globpath(wn, "**/*.md", true, true)
+  local nd = mod.get_mod ("note").config.note_folder
+  local wn = vim.fs.joinpath (workspace, nd)
+  return vim.fn.globpath (wn, "**/*.md", true, true)
 end
 
-Workspace.names = function()
-  return vim.tbl_keys(Workspace.data.workspaces)
+Workspace.names = function ()
+  return vim.tbl_keys (Workspace.data.workspaces)
 end
 
-Workspace.workspaces = function()
+Workspace.workspaces = function ()
   return Workspace.data.workspaces
 end
 
-Workspace.paths = function()
-  return vim.tbl_values(Workspace.data.workspaces)
+Workspace.paths = function ()
+  return vim.tbl_values (Workspace.data.workspaces)
 end
 --- Returns a list of all files relative path from a `wsname`
 ---@param name string
 ---@return string[]?
-Workspace.markdown = function(name)
-  return fn.globpath(Workspace.get(name), "**/*.md", true, true)
+Workspace.markdown = function (name)
+  return fn.globpath (Workspace.get (name), "**/*.md", true, true)
 end
 --- Sets the current workspace and opens that workspace's index file
 ---@param workspace string #The name of the workspace to open
-Workspace.open = function(workspace)
-  local ws_match = Workspace.get(workspace)
+Workspace.open = function (workspace)
+  local ws_match = Workspace.get (workspace)
   if not ws_match then
-    log.error(
+    log.error (
       'Unable to switch to workspace - "' .. workspace .. '" does not exist'
     )
     return
   end
-  Workspace.set_workspace(workspace)
+  Workspace.set_workspace (workspace)
   if workspace ~= "default" then
-    vim.cmd("e " .. Workspace.index(ws_match))
+    vim.cmd ("e " .. Workspace.index (ws_match))
   end
 end
 --- Touches a file in workspace
 ---@param p string
 ---@param workspace string
-Workspace.touch = function(p, workspace)
-  vim.validate({
+Workspace.touch = function (p, workspace)
+  vim.validate ({
     path = { p, "string", "table" },
     workspace = { workspace, "string" },
   })
-  local ws_match = Workspace.get(workspace)
+  local ws_match = Workspace.get (workspace)
   if not workspace then
     return false
   end
-  return fn.writefile({}, fs.joinpath(ws_match, p))
+  return fn.writefile ({}, fs.joinpath (ws_match, p))
 end
-Workspace.new_note = function()
+Workspace.new_note = function ()
   if Workspace.config.use_popup then
-    Workspace.dep.ui.new_prompt("downNewNote", "New Note: ", function(text)
-      Workspace.new_file(text)
+    Workspace.dep.ui.new_prompt ("downNewNote", "New Note: ", function (text)
+      Workspace.new_file (text)
     end, {
       center_x = true,
       center_y = true,
@@ -463,65 +470,65 @@ Workspace.new_note = function()
       col = 0,
     })
   else
-    vim.ui.input({ prompt = "New Note: " }, function(text)
+    vim.ui.input ({ prompt = "New Note: " }, function (text)
       if text ~= nil and #text > 0 then
-        Workspace.new_file(text)
+        Workspace.new_file (text)
       end
     end)
   end
 end
 
-Workspace.subpath = function(p, wsname)
-  local wsp = Workspace.get_dir(wsname)
-  return fs.joinpath(wsp, p)
+Workspace.subpath = function (p, wsname)
+  local wsp = Workspace.get_dir (wsname)
+  return fs.joinpath (wsp, p)
 end
 
-Workspace.is_subpath = function(p, wsname)
-  local wsp = Workspace.get_dir(wsname)
-  return not not p:match("^" .. wsp)
+Workspace.is_subpath = function (p, wsname)
+  local wsp = Workspace.get_dir (wsname)
+  return not not p:match ("^" .. wsp)
 end
 
 --- Edit index of current directory
 --- @param e down.Event
-Workspace.edit_index = function(e)
-  local c = e.body[1] or Workspace.current()
-  local ws = fs.normalize(fn.expand(Workspace.get(c)))
-  fn.mkdir(ws, "p")
-  local index = Workspace.index(ws)
-  if fn.filereadable(index) == 0 then
-    if not fn.writefile({}, index) then
-      return vim.notify("Failed to create index file")
+Workspace.edit_index = function (e)
+  local c = e.body[1] or Workspace.current ()
+  local ws = fs.normalize (fn.expand (Workspace.get (c)))
+  fn.mkdir (ws, "p")
+  local index = Workspace.index (ws)
+  if fn.filereadable (index) == 0 then
+    if not fn.writefile ({}, index) then
+      return vim.notify ("Failed to create index file")
     end
   end
-  Workspace.edit(index)
+  Workspace.edit (index)
 end
 
 --- @param prompt? string | nil
 --- @param fmt? fun(item: string): string
 --- @param fn? fun(item: number|string, idx: number|string)|nil
-Workspace.select_file = function(prompt, fmt, fn)
+Workspace.select_file = function (prompt, fmt, fn)
   local format = fmt
-    or function(item)
-      local current = vim.fn.expand("%:p")
+    or function (item)
+      local current = vim.fn.expand ("%:p")
       if item == current then
         return "• " .. item
       end
       return item
     end
   local func = fn
-    or function(item, idx)
-      local current = vim.fn.expand("%:p")
+    or function (item, idx)
+      local current = vim.fn.expand ("%:p")
       if not item then
         return
       elseif item == current then
-        vim.notify("Already editing " .. current)
+        vim.notify ("Already editing " .. current)
       else
-        vim.notify("Editing " .. item)
-        Workspace.edit(item)
+        vim.notify ("Editing " .. item)
+        Workspace.edit (item)
       end
-      Workspace.edit(item)
+      Workspace.edit (item)
     end
-  return vim.ui.select(Workspace.markdown(Workspace.current()) or {}, {
+  return vim.ui.select (Workspace.markdown (Workspace.current ()) or {}, {
     prompt = prompt or "Select markdown file in workspace",
     format_items = format,
   }, func)
@@ -529,38 +536,38 @@ end
 
 --- Select markdown file in current workspace
 ---@param e down.Event
-Workspace.filemenu = function(e)
+Workspace.filemenu = function (e)
   if e.body and e.body[1] then
-    Workspace.edit(e.body[1])
+    Workspace.edit (e.body[1])
   else
-    Workspace.select_file()
+    Workspace.select_file ()
   end
 end
 
 --- Select workspace
 --- @param e down.Event
-Workspace.menu = function(e)
+Workspace.menu = function (e)
   if e.body and e.body[1] then
-    Workspace.open(e.body[1])
-    vim.schedule(function()
-      local new_workspace = Workspace.get(e.body[1])
+    Workspace.open (e.body[1])
+    vim.schedule (function ()
+      local new_workspace = Workspace.get (e.body[1])
       if not new_workspace then
-        Workspace.select()
+        Workspace.select ()
       end
-      vim.notify("Workspace: " .. e.body[1] .. " -> " .. new_workspace)
+      vim.notify ("Workspace: " .. e.body[1] .. " -> " .. new_workspace)
     end)
   else
-    Workspace.select()
+    Workspace.select ()
   end
 end
 
-Workspace.fmt = function()
+Workspace.fmt = function ()
   return vim
-    .iter(Workspace.workspaces())
-    :map(function(k, v)
+    .iter (Workspace.workspaces ())
+    :map (function (k, v)
       return k .. " -> " .. v
     end)
-    :totable()
+    :totable ()
 end
 
 ---@class down.mod.workspace.Commands: { [string]: down.Command }
@@ -570,9 +577,9 @@ Workspace.commands = {
     min_args = 0,
     max_args = 1,
     name = "workspace.index",
-    complete = { Workspace.names() },
-    callback = function(e)
-      Workspace.edit_index(e)
+    complete = { Workspace.names () },
+    callback = function (e)
+      Workspace.edit_index (e)
     end,
   },
   workspace = {
@@ -580,9 +587,9 @@ Workspace.commands = {
     max_args = 1,
     enabled = true,
     name = "workspace.workspace",
-    complete = { Workspace.names() },
-    callback = function(e)
-      Workspace.menu(e)
+    complete = { Workspace.names () },
+    callback = function (e)
+      Workspace.menu (e)
     end,
   },
   edit = {
@@ -590,37 +597,37 @@ Workspace.commands = {
     max_args = 1,
     enabled = true,
     name = "workspace.edit",
-    callback = function(e)
-      Workspace.filemenu(e)
+    callback = function (e)
+      Workspace.filemenu (e)
     end,
     complete = {
-      Workspace.markdown(Workspace.current()),
+      Workspace.markdown (Workspace.current ()),
     },
   },
 }
 
 ---@class down.mod.workspace.Events
 Workspace.events = {
-  wschanged = event.define(Workspace, "wschanged"),
-  wsadded = event.define(Workspace, "wsadded"),
-  wscache_empty = event.define(Workspace, "wscache_empty"),
-  file_created = event.define(Workspace, "file_created"),
+  wschanged = event.define (Workspace, "wschanged"),
+  wsadded = event.define (Workspace, "wsadded"),
+  wscache_empty = event.define (Workspace, "wscache_empty"),
+  file_created = event.define (Workspace, "file_created"),
 }
 
 ---@class down.mod.workspace.Subscribed
 Workspace.handle = {
   workspace = {
-    wsadded = function(e)
-      log.trace(e, "wsadded")
+    wsadded = function (e)
+      log.trace (e, "wsadded")
     end,
-    file_created = function(e)
-      log.trace("filecreated", e)
+    file_created = function (e)
+      log.trace ("filecreated", e)
     end,
-    wscache_empty = function(e)
-      log.trace("wscache_empty", e)
+    wscache_empty = function (e)
+      log.trace ("wscache_empty", e)
     end,
-    wschanged = function(e)
-      log.trace("wschanged", e)
+    wschanged = function (e)
+      log.trace ("wschanged", e)
     end,
   },
 }

--- a/lua/down/util/init.lua
+++ b/lua/down/util/init.lua
@@ -1,20 +1,31 @@
 ---@class down.Util
 local U = {}
 
-log = require("down.log")
+local log = require ("down.log")
 
 local c, f, a, ts = vim.cmd, vim.fn, vim.api, vim.treesitter
 
 ---@return down.Os
-U.os = function()
-  return string.lower(require("ffi").os)
+U.os = function ()
+  local ok, ffi = pcall (require, "ffi")
+  if ok and ffi then
+    return string.lower (ffi.os)
+  end
+  local sysname = vim.loop.os_uname ().sysname
+  if sysname == "Windows_NT" then
+    return "windows"
+  elseif sysname == "Darwin" then
+    return "mac"
+  else
+    return "linux"
+  end
 end
 
-U.sep = U.os() == "windows" and "\\" or "/"
+U.sep = (vim.fn.has ("win32") == 1) and "\\" or "/"
 
-U.tobool = function(str)
+U.tobool = function (str)
   local bool = false
-  str = (str:gsub(" ", ""))
+  str = (str:gsub (" ", ""))
   if str == "true" then
     bool = true
   end
@@ -26,8 +37,8 @@ end
 --- @param func fun(...: any): T The function to invoke in a protected environment.
 --- @param ... any The parameters to pass to `func`.
 --- @return T? # The return value of the executed function or `nil`.
-function U.inline_pcall(func, ...)
-  local ok, ret = pcall(func, ...)
+function U.inline_pcall (func, ...)
+  local ok, ret = pcall (func, ...)
 
   if ok then
     return ret
@@ -35,78 +46,78 @@ function U.inline_pcall(func, ...)
 
   -- return nil
 end
-U.version = vim.version() -- TODO: Move to a more local scope
+U.version = vim.version () -- TODO: Move to a more local scope
 
 --- A version agnostic way to call the neovim treesitter query parser
 --- @param language string # Language to use for the query
 --- @param query_string string # Query in s-expr syntax
 --- @return ts.Query # Parsed query
-function U.ts_parse_query(language, query_string)
+function U.ts_parse_query (language, query_string)
   if ts.query.parse then
-    return ts.query.parse(language, query_string)
+    return ts.query.parse (language, query_string)
   else
     ---@diagnostic disable-next-line
-    return ts.parse_query(language, query_string)
+    return ts.parse_query (language, query_string)
   end
 end
 
 --- An OS agnostic way of querying the current user
 --- @return string username
-function U.get_username()
-  local current_os = U.os()
+function U.get_username ()
+  local current_os = U.os ()
   if not current_os then
     return ""
   end
 
   if current_os == "linux" or current_os == "mac" or current_os == "wsl" then
-    return os.getenv("USER") or ""
+    return os.getenv ("USER") or ""
   elseif current_os == "windows" then
-    return os.getenv("username") or ""
+    return os.getenv ("username") or ""
   end
 
   return ""
 end
 
-function U.extend(t1, t2)
-  return vim.tbl_deep_extend("force", t1, t2)
+function U.extend (t1, t2)
+  return vim.tbl_deep_extend ("force", t1, t2)
 end
 
-function U.dext(t1, t2)
-  return vim.tbl_deep_extend("force", t1, t2)
+function U.dext (t1, t2)
+  return vim.tbl_deep_extend ("force", t1, t2)
 end
 
-function U.ext(t1, t2)
-  return vim.tbl_extend("force", t1, t2)
+function U.ext (t1, t2)
+  return vim.tbl_extend ("force", t1, t2)
 end
 
 --- Returns an array of strings, the array being a list of languages that down can inject.
 ---@param values boolean If set to true will return an array of strings, if false will return a key-value table.
 ---@return string[]|table<string, { type: "integration.treesitter"  |"syntax"|"null" }>
-function U.get_language_list(values)
+function U.get_language_list (values)
   local regex_files = {}
   local ts_files = {}
 
   -- Search for regex files in syntax and after/syntax.
   -- Its best if we strip out anything but the ft name.
-  for _, lang in pairs(a.nvim_get_runtime_file("syntax/*.vim", true)) do
-    local lang_name = f.fnamemodify(lang, ":t:r")
-    table.insert(regex_files, lang_name)
+  for _, lang in pairs (a.nvim_get_runtime_file ("syntax/*.vim", true)) do
+    local lang_name = f.fnamemodify (lang, ":t:r")
+    table.insert (regex_files, lang_name)
   end
 
-  for _, lang in pairs(a.nvim_get_runtime_file("after/syntax/*.vim", true)) do
-    local lang_name = f.fnamemodify(lang, ":t:r")
-    table.insert(regex_files, lang_name)
+  for _, lang in pairs (a.nvim_get_runtime_file ("after/syntax/*.vim", true)) do
+    local lang_name = f.fnamemodify (lang, ":t:r")
+    table.insert (regex_files, lang_name)
   end
 
   -- Search for available parsers
-  for _, parser in pairs(a.nvim_get_runtime_file("parser/*.so", true)) do
-    local parser_name = assert(f.fnamemodify(parser, ":t:r"))
+  for _, parser in pairs (a.nvim_get_runtime_file ("parser/*.so", true)) do
+    local parser_name = assert (f.fnamemodify (parser, ":t:r"))
     ts_files[parser_name] = true
   end
 
   local ret = {}
 
-  for _, syntax in pairs(regex_files) do
+  for _, syntax in pairs (regex_files) do
     if ts_files[syntax] then
       ret[syntax] = { type = "integration.treesitter" }
     else
@@ -114,13 +125,13 @@ function U.get_language_list(values)
     end
   end
 
-  return values and vim.tbl_keys(ret) or ret
+  return values and vim.tbl_keys (ret) or ret
 end
 
 --- Gets a list of shorthands for a given language.
 --- @param reverse_lookup boolean Whether to create a reverse lookup for the table.
 --- @return LanguageList
-function U.get_language_shorthands(reverse_lookup)
+function U.get_language_shorthands (reverse_lookup)
   ---@class LanguageList
   local langs = {
     ["bash"] = { "sh", "zsh" },
@@ -153,7 +164,7 @@ function U.get_language_shorthands(reverse_lookup)
   -- TODO: `vim.tbl_add_reverse_lookup` deprecated: NO ALTERNATIVES
   -- GOOD JOB base DEVS
   -- <https://github.com/neovim/neovim/pull/27639>
-  return reverse_lookup and vim.tbl_add_reverse_lookup(langs) or langs ---@diagnostic disable-line
+  return reverse_lookup and vim.tbl_add_reverse_lookup (langs) or langs ---@diagnostic disable-line
 end
 
 --- Checks whether Neovim is running at least at a specific version.
@@ -161,7 +172,7 @@ end
 --- @param minor number The minor release of Neovim.
 --- @param patch number The patch number (in case you need it).
 --- @return boolean # Whether Neovim is running at the same or a higher version than the one given.
-function U.is_minimum_version(major, minor, patch)
+function U.is_minimum_version (major, minor, patch)
   if major ~= version.major then
     return major < version.major
   end
@@ -177,20 +188,20 @@ end
 --- Parses a version string like "0.4.2" and provides back a table like { major = <number>, minor = <number>, patch = <number> }
 --- @param version_string string The input string.
 --- @return table? # The parsed version string, or `nil` if a failure occurred during parsing.
-function U.parse_version_string(version_string)
+function U.parse_version_string (version_string)
   if not version_string then
     return
   end
 
   -- Define variables that split the version up into 3 slices
   local split_version, versions, ret =
-    vim.split(version_string, ".", { plain = true }),
+    vim.split (version_string, ".", { plain = true }),
     { "major", "minor", "patch" },
     { major = 0, minor = 0, patch = 0 }
 
   -- If the sliced version string has more than 3 elements error out
   if #split_version > 3 then
-    log.warn(
+    log.warn (
       "Attempt to parse version:",
       version_string,
       "failed - too many version numbers provided. Version should follow this layout: <major>.<minor>.<patch>"
@@ -199,12 +210,12 @@ function U.parse_version_string(version_string)
   end
 
   -- Loop through all the versions and check whether they are valid numbers. If they are, add them to the return table
-  for i, ver in ipairs(versions) do
+  for i, ver in ipairs (versions) do
     if split_version[i] then
-      local num = tonumber(split_version[i])
+      local num = tonumber (split_version[i])
 
       if not num then
-        log.warn(
+        log.warn (
           "Invalid version provided, string cannot be converted to integral type."
         )
         return
@@ -219,15 +230,15 @@ end
 --- Capitalizes the first letter of each down in a given string.
 --- @param str string The string to capitalize.
 --- @return string # The capitalized string.
-function U.title(str)
+function U.title (str)
   local result = {}
 
-  for w in str:gmatch("[^%s]+") do
-    local lower = w:sub(2):lower()
+  for w in str:gmatch ("[^%s]+") do
+    local lower = w:sub (2):lower ()
 
-    table.insert(result, w:sub(1, 1):upper() .. lower)
+    table.insert (result, w:sub (1, 1):upper () .. lower)
   end
-  return table.concat(result, " ")
+  return table.concat (result, " ")
 end
 
 --- Lazily concatenates a string to prevent runtime errors where an object may not exist
@@ -243,18 +254,18 @@ end
 --- To mitigate this issue directly.
 --- @param ... string An unlimited number of strings.
 --- @return string # The result of all the strings concatenated.
-function U.lazy_string_concat(...)
-  return table.concat({ ... })
+function U.lazy_string_concat (...)
+  return table.concat ({ ... })
 end
 --- Constructs a new key-pair table by running a callback on all elements of an array.
 --- @param keys string[] A string array with the keys to iterate over.
 --- @param cb fun(key: string): any? A function that gets invoked with each key and returns a value to be placed in the output table.
 --- @return table # The newly constructed table.
-function U.construct(keys, cb)
+function U.construct (keys, cb)
   local result = {}
 
-  for _, key in ipairs(keys) do
-    result[key] = cb(key)
+  for _, key in ipairs (keys) do
+    result[key] = cb (key)
   end
 
   return result
@@ -264,9 +275,9 @@ end
 --- @param val function|any Either a function or any other value.
 --- @param ... any Potential arguments to give `val` if it is a function.
 --- @return any # The returned evaluation of `val`.
-function U.eval(val, ...)
-  if type(val) == "function" then
-    return val(...)
+function U.eval (val, ...)
+  if type (val) == "function" then
+    return val (...)
   end
 
   return val
@@ -276,7 +287,7 @@ end
 --- @param min number The lower bound.
 --- @param max number The higher bound.
 --- @return number # The wrapped number, guarantees `min <= value <= max`.
-function U.number_wrap(value, min, max)
+function U.number_wrap (value, min, max)
   local range = max - min + 1
   local wrapped_value = ((value - min) % range) + min
 
@@ -291,10 +302,10 @@ end
 --- @param value any The value to compare against.
 --- @param compare? fun(lhs: any, rhs: any): boolean A custom comparison function.
 --- @return fun(statements: table<any, any>): any # A function to invoke with a table of potential matches.
-function U.match(value, compare)
+function U.match (value, compare)
   -- Returning a function allows for such syntax:
   -- match(something) { ...atches...}
-  return function(statements)
+  return function (statements)
     if value == nil then
       return
     end
@@ -305,9 +316,9 @@ function U.match(value, compare)
     -- The default comparison function compares booleans as strings to ensure
     -- that boolean comparisons work as intended.
     compare = compare
-      or function(lhs, rhs)
-        if type(lhs) == "boolean" then
-          return tostring(lhs) == rhs
+      or function (lhs, rhs)
+        if type (lhs) == "boolean" then
+          return tostring (lhs) == rhs
         end
 
         return lhs == rhs
@@ -315,15 +326,15 @@ function U.match(value, compare)
 
     -- Go through every statement, compare it, and perform the desired action
     -- if the comparison was successful
-    for case, action in pairs(statements) do
+    for case, action in pairs (statements) do
       -- If the case statement is a list of data then compare that
-      if type(case) == "table" and vim.tbl_islist(case) then
-        for _, subcase in ipairs(case) do
-          if compare(value, subcase) then
+      if type (case) == "table" and vim.tbl_islist (case) then
+        for _, subcase in ipairs (case) do
+          if compare (value, subcase) then
             -- The action can be a function, in which case it is invoked
             -- and the return value of that function is returned instead.
-            if type(action) == "function" then
-              return action(value)
+            if type (action) == "function" then
+              return action (value)
             end
 
             return action
@@ -331,11 +342,11 @@ function U.match(value, compare)
         end
       end
 
-      if compare(value, case) then
+      if compare (value, case) then
         -- The action can be a function, in which case it is invoked
         -- and the return value of that function is returned instead.
-        if type(action) == "function" then
-          return action(value)
+        if type (action) == "function" then
+          return action (value)
         end
 
         return action
@@ -347,8 +358,8 @@ function U.match(value, compare)
     if statements._ then
       local action = statements._
 
-      if type(action) == "function" then
-        return action(value)
+      if type (action) == "function" then
+        return action (value)
       end
 
       return action
@@ -361,14 +372,14 @@ end
 --- @param when_false function|any The value to return when `comparison` is false.
 --- @return any # The value that either `when_true` or `when_false` returned.
 --- @see down.core.lib.match
-function U.when(comparison, when_true, when_false)
-  if type(comparison) ~= "boolean" then
+function U.when (comparison, when_true, when_false)
+  if type (comparison) ~= "boolean" then
     comparison = (comparison ~= nil)
   end
 
-  return U.match(
-    type(comparison) == "table" and unpack(comparison) or comparison
-  )({
+  return U.match (
+    type (comparison) == "table" and unpack (comparison) or comparison
+  ) ({
     ["true"] = when_true,
     ["false"] = when_false,
   })
@@ -377,46 +388,46 @@ end
 --- Custom down notifications. Wrapper around `vim.notify`.
 --- @param msg string Message to send.
 --- @param log_level integer? Log level in `vim.log.levels`.
-function U.notify(msg, log_level)
-  vim.notify(msg, log_level, { title = "down" })
+function U.notify (msg, log_level)
+  vim.notify (msg, log_level, { title = "down" })
 end
 
 --- Opens up an array of files and runs a callback for each opened file.
 --- @param files (string)[] An array of files to open.
 --- @param callback fun(buffer: integer, filename: string) The callback to invoke for each file.
-function U.read_files(files, callback)
-  for _, file in ipairs(files) do
-    file = tostring(file)
-    local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(file))
+function U.read_files (files, callback)
+  for _, file in ipairs (files) do
+    file = tostring (file)
+    local bufnr = vim.uri_to_bufnr (vim.uri_from_fname (file))
 
-    local should_delete = not a.nvim_buf_is_loaded(bufnr)
+    local should_delete = not a.nvim_buf_is_loaded (bufnr)
 
-    f.bufload(bufnr)
-    callback(bufnr, file)
+    f.bufload (bufnr)
+    callback (bufnr, file)
     if should_delete then
-      a.nvim_buf_delete(bufnr, { force = true })
+      a.nvim_buf_delete (bufnr, { force = true })
     end
   end
 end
 
 -- following https://gist.github.com/kylechui/a5c1258cd2d86755f97b10fc921315c3
-function U.set_operatorfunc(f)
+function U.set_operatorfunc (f)
   U._down_operatorfunc = f
   vim.go.operatorfunc = "v:lua.require'down'.U._down_operatorfunc"
 end
 
-function U.wrap_dotrepeat(callback)
-  return function(...)
-    if a.nvim_get_mode().mode == "i" then
-      callback(...)
+function U.wrap_dotrepeat (callback)
+  return function (...)
+    if a.nvim_get_mode ().mode == "i" then
+      callback (...)
       return
     end
 
     local args = { ... }
-    U.set_operatorfunc(function()
-      callback(unpack(args))
+    U.set_operatorfunc (function ()
+      callback (unpack (args))
     end)
-    c("normal! g@l")
+    c ("normal! g@l")
   end
 end
 --- Wraps a function in a callback.
@@ -424,21 +435,21 @@ end
 --- @param function_pointer T The function to wrap.
 --- @param ... A The arguments to pass to the wrapped function.
 --- @return fun(...: A): T # The wrapped function in a callback.
-function U.wrap(function_pointer, ...)
+function U.wrap (function_pointer, ...)
   local params = { ... }
 
-  if type(function_pointer) ~= "function" then
+  if type (function_pointer) ~= "function" then
     local prev = function_pointer
 
     -- luacheck: push ignore
-    function_pointer = function()
-      return prev, unpack(params)
+    function_pointer = function ()
+      return prev, unpack (params)
     end
     -- luacheck: pop
   end
 
-  return function()
-    return function_pointer(unpack(params))
+  return function ()
+    return function_pointer (unpack (params))
   end
 end
 
@@ -447,44 +458,44 @@ local strcharpt, strwidth, strchars = f.strcharpart, a.nvim_strwidth, f.strchars
 --- @param str string The string to limit.
 --- @param col_limit integer `str` will be cut so that when displayed, the display length does not exceed this limit.
 --- @return string # Substring of input str
-function U.truncate_by_cell(str, col_limit)
-  if str and str:len() == strwidth(str) then
-    return strcharpt(str, 0, col_limit)
+function U.truncate_by_cell (str, col_limit)
+  if str and str:len () == strwidth (str) then
+    return strcharpt (str, 0, col_limit)
   end
-  local short = strcharpt(str, 0, col_limit)
-  if strwidth(short) > col_limit then
-    while strwidth(short) > col_limit do
-      short = strcharpt(short, 0, strchars(short) - 1)
+  local short = strcharpt (str, 0, col_limit)
+  if strwidth (short) > col_limit then
+    while strwidth (short) > col_limit do
+      short = strcharpt (short, 0, strchars (short) - 1)
     end
   end
   return short
 end
 
 ---@return down.Os
-function U.get_os()
-  local os = (vim.loop or vim.uv).os_uname().sysname:lower()
-  if os:find("windows_nt") then
+function U.get_os ()
+  local os = (vim.loop or vim.uv).os_uname ().sysname:lower ()
+  if os:find ("windows_nt") then
     return "windows"
   elseif os == "darwin" then
     return "mac"
   elseif os == "linux" then
-    local f = io.open("/proc/version", "r")
+    local f = io.open ("/proc/version", "r")
     if f ~= nil then
-      local version = f:read("*all")
-      f:close()
-      if version:find("WSL2") then
+      local version = f:read ("*all")
+      f:close ()
+      if version:find ("WSL2") then
         return "wsl2"
-      elseif version:find("microsoft") then
+      elseif version:find ("microsoft") then
         return "wsl"
       end
     end
     return "linux"
-  elseif os:find("bsd") then
+  elseif os:find ("bsd") then
     return "bsd"
   end
-  error("[down]: Unable to determine the currently active operating system!")
+  error ("[down]: Unable to determine the currently active operating system!")
 end
 
-U.string = require("down.util.string")
+U.string = require ("down.util.string")
 
 return U

--- a/plugin/down.lua
+++ b/plugin/down.lua
@@ -1,0 +1,50 @@
+if vim.g.down_loaded then
+  return
+end
+vim.g.down_loaded = true
+
+vim.api.nvim_create_user_command ("Down", function (data)
+  local ok, down = pcall (require, "down")
+  if not ok then
+    vim.notify (
+      "[down.nvim] Failed to load: " .. tostring (down),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+  if not down.config.started then
+    down.setup (vim.g.down_config or {})
+  end
+  local cmd_mod = require ("down.mod").mods["cmd"]
+  if cmd_mod and cmd_mod.cb then
+    cmd_mod.cb (data)
+  else
+    vim.notify ("[down.nvim] Command module not loaded", vim.log.levels.WARN)
+  end
+end, {
+  desc = "down.nvim command",
+  range = 2,
+  force = true,
+  nargs = "*",
+  complete = function (arg_lead, cmd_line, cursor_pos)
+    local ok, mod = pcall (require, "down.mod")
+    if not ok then
+      return {}
+    end
+    local cmd_mod = mod.mods["cmd"]
+    if cmd_mod and cmd_mod.generate_completions then
+      return cmd_mod.generate_completions (nil, cmd_line) or {}
+    end
+    return {}
+  end,
+})
+
+vim.api.nvim_create_autocmd ("FileType", {
+  pattern = "markdown",
+  callback = function ()
+    local ok, down = pcall (require, "down")
+    if ok and down.config.started then
+      return
+    end
+  end,
+})


### PR DESCRIPTION
## Summary

The plugin was non-functional — no `plugin/` entry point existed, circular `require("down")` calls in modules caused load failures, and config loading had broken logic. This PR makes down.nvim fully operational as a Neovim plugin again, adds auto-download + enablement of `down.lsp` and `down.mcp`, and wires up the knowledge graph.

### Critical fixes:
- **Add `plugin/down.lua`** — Neovim's runtime discovery mechanism; provides `:Down` command + lazy setup
- **Break circular deps** — `cmd/init.lua`, `note/init.lua`, `ui/hl`, `ui/icon`, `ui/calendar/month`, `data/time` all had `local down = require("down")` at top level → replaced with direct `require("down.mod")`, `require("down.log")` etc.
- **Fix `config:load()` guard** — `(not type(user) == "table")` → `type(user) ~= "table"` (operator precedence bug)
- **Fix `util/init.lua` FFI** — `U.sep` was evaluated at require-time via `require("ffi").os` → now uses `vim.fn.has("win32")` + `pcall` fallback
- **Fix `check_id`** — was excluding `"workspace"` from loadable modules
- **Fix workspace `__newindex`/`sync`** — crashed on `Workspace.dep["data"]` before dep loaded

### New modules:
- **`lua/down/mod/lsp/init.lua`** — detects platform, auto-downloads `clpi/down.lsp` binary from GitHub releases, starts LSP client for markdown via `vim.lsp.start()`, exposes `:Down lsp {start,install,status}`
- **`lua/down/mod/mcp/init.lua`** — same pattern for `clpi/down.mcp` MCP server, manages background process lifecycle, exposes `:Down mcp {start,stop,install,status}`
- **`lua/down/mod/data/knowledge/init.lua`** (enhanced) — extracts `[[wiki-links]]` and `#tags` from workspace files, builds in-memory entity/relation graph, persists via data module, exposes `:Down knowledge {index,query,stats}`

### Setup:
```lua
require("down").setup({
  workspace = {
    default = "notes",
    workspaces = { notes = "~/notes" },
  },
  lsp = { auto_download = true },
  mcp = { auto_download = true },
})
```

Tested with Neovim 0.10.4 — 18 modules load successfully, all `:Down` subcommands functional.

Link to Devin session: https://app.devin.ai/sessions/d912b739bf934f54b8d9b74f677a2b94
Requested by: @clpi